### PR TITLE
Expose vision service environment variables

### DIFF
--- a/camera-food-reciepe-main/.gitignore
+++ b/camera-food-reciepe-main/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env*
+.DS_Store

--- a/camera-food-reciepe-main/README.md
+++ b/camera-food-reciepe-main/README.md
@@ -15,6 +15,9 @@ View your app in AI Studio: https://ai.studio/apps/drive/1iNDCanOspkZrC13tqzikF_
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the following environment variables in [.env.local](.env.local):
+   - `GEMINI_API_KEY` for your Gemini access token.
+   - `VISION_API_URL` pointing to the HTTPS endpoint of your image analysis service.
+   - `VISION_API_KEY` (optional) if your service requires bearer-token authentication.
 3. Run the app:
    `npm run dev`

--- a/camera-food-reciepe-main/vite.config.ts
+++ b/camera-food-reciepe-main/vite.config.ts
@@ -8,7 +8,9 @@ export default defineConfig(({ mode }) => {
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.VISION_API_URL': JSON.stringify(env.VISION_API_URL),
+        'process.env.VISION_API_KEY': JSON.stringify(env.VISION_API_KEY),
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- inject VISION_API_URL and VISION_API_KEY into the Vite build so the frontend can read the vision endpoint configuration
- document the required Vision environment variables alongside the Gemini key
- add a .gitignore to keep build outputs and local env files out of version control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2259c93c8832890f43f50ec0dfac8