### PR TITLE
Add Gemini fallback for ingredient vision analysis

### DIFF
--- a/camera-food-reciepe-main/README.md
+++ b/camera-food-reciepe-main/README.md
@@ -18,12 +18,12 @@ index a4812bcc3d031391576f28ff39962d87816fa3b5..34646da0c8082de1c89b719a08de0b4d
  **Prerequisites:**  Node.js
  
  
- 1. Install dependencies:
-    `npm install`
--2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-+2. Set the following environment variables in [.env.local](.env.local):
-+   - `GEMINI_API_KEY` for your Gemini access token.
-+   - `VISION_API_URL` pointing to the HTTPS endpoint of your image analysis service.
-+   - `VISION_API_KEY` (optional) if your service requires bearer-token authentication.
- 3. Run the app:
-    `npm run dev`
+1. Install dependencies:
+   `npm install`
+2. Set the following environment variables in [.env.local](.env.local):
+   - `GEMINI_API_KEY` for your Gemini access token. This key powers both text recipes and the built-in vision fallback.
+   - `VISION_API_URL` (optional) pointing to the HTTPS endpoint of your custom image analysis service.
+   - `VISION_API_KEY` (optional) if your service requires bearer-token authentication.
+   - If you do not provide a `VISION_API_URL`, the app will automatically analyze photos with Gemini 1.5 Flash using the `GEMINI_API_KEY`.
+3. Run the app:
+   `npm run dev`

--- a/camera-food-reciepe-main/locales/en.ts
+++ b/camera-food-reciepe-main/locales/en.ts
@@ -71,7 +71,8 @@ export const errorNoIngredientsFound = 'No recognizable ingredients were found. 
 export const errorPhotoAnalysis = 'We could not analyse that photo. Please try again.';
 export const errorUnknown = 'An unknown error occurred.';
 
-export const error_gemini_api_key = 'Gemini API key is not configured. Please set the API_KEY environment variable.';
+export const error_gemini_api_key =
+  'Gemini API key is not configured. Please set the GEMINI_API_KEY (or legacy API_KEY) environment variable.';
 export const error_gemini_fetch = 'Failed to fetch recipes. Please try again later.';
 export const error_youtube_api_key = 'API_KEY environment variable is not set. No recipe videos will be returned.';
 export const error_youtube_fetch = 'Failed to fetch recipe videos. Please try again later.';

--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -71,7 +71,8 @@ export const errorNoIngredientsFound = '인식할 수 있는 재료를 찾지 �
 export const errorPhotoAnalysis = '사진을 분석할 수 없었어요. 다시 시도해주세요.';
 export const errorUnknown = '알 수 없는 오류가 발생했습니다.';
 
-export const error_gemini_api_key = 'Gemini API 키가 설정되지 않았어요. API_KEY 환경 변수를 확인해주세요.';
+export const error_gemini_api_key =
+  'Gemini API 키가 설정되지 않았어요. GEMINI_API_KEY (또는 기존 API_KEY) 환경 변수를 확인해주세요.';
 export const error_gemini_fetch = '레시피를 불러오지 못했어요. 잠시 후 다시 시도해주세요.';
 export const error_youtube_api_key = 'API_KEY 환경 변수가 설정되지 않았습니다. 레시피 영상이 반환되지 않습니다.';
 export const error_youtube_fetch = '레시피 영상을 불러오지 못했어요. 잠시 후 다시 시도해주세요.';

--- a/camera-food-reciepe-main/services/geminiService.ts
+++ b/camera-food-reciepe-main/services/geminiService.ts
@@ -1,9 +1,10 @@
 import { GoogleGenAI, Type } from '@google/genai';
 import type { Recipe } from '../types';
 
-const API_KEY = process.env.API_KEY as string | undefined;
+const GEMINI_API_KEY =
+  (process.env.GEMINI_API_KEY as string | undefined) ?? (process.env.API_KEY as string | undefined);
 
-const ai = API_KEY ? new GoogleGenAI({ apiKey: API_KEY }) : null;
+const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
 
 const recipeSchema = {
     type: Type.ARRAY,
@@ -31,7 +32,7 @@ const recipeSchema = {
 };
 
 export async function getRecipeSuggestions(ingredients: string[], language: 'en' | 'ko'): Promise<Recipe[]> {
-    if (!API_KEY || !ai) {
+    if (!GEMINI_API_KEY || !ai) {
         throw new Error('error_gemini_api_key');
     }
     if (ingredients.length === 0) {

--- a/camera-food-reciepe-main/services/visionService.ts
+++ b/camera-food-reciepe-main/services/visionService.ts
@@ -1,11 +1,93 @@
+import { GoogleGenAI, Type } from '@google/genai';
+
 const VISION_ENDPOINT = process.env.VISION_API_URL as string | undefined;
 const VISION_API_KEY = process.env.VISION_API_KEY as string | undefined;
+const GEMINI_API_KEY =
+  (process.env.GEMINI_API_KEY as string | undefined) ?? (process.env.API_KEY as string | undefined);
+
+const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
+
+const ingredientSchema = {
+  type: Type.ARRAY,
+  items: {
+    type: Type.STRING,
+    description:
+      'Single-word or short food ingredient names that appear clearly in the provided image of refrigerator or pantry items.',
+  },
+};
 
 interface VisionResponse {
   ingredients?: string[];
 }
 
-export async function analyzeIngredientsFromImage(image: Blob): Promise<string[]> {
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  if (typeof Buffer !== 'undefined') {
+    // Fallback for environments where btoa is not available (e.g. some Node test runners)
+    return Buffer.from(binary, 'binary').toString('base64');
+  }
+  throw new Error('Base64 encoding is not supported in this environment.');
+}
+
+async function analyzeWithGemini(image: Blob): Promise<string[]> {
+  if (!ai || !GEMINI_API_KEY) {
+    throw new Error('error_gemini_api_key');
+  }
+
+  try {
+    const arrayBuffer = await image.arrayBuffer();
+    const base64 = arrayBufferToBase64(arrayBuffer);
+
+    const response = await ai.models.generateContent({
+      model: 'gemini-1.5-flash',
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              text:
+                'Identify all visible, usable food ingredients in this refrigerator or pantry photo. Respond with a JSON array of distinct ingredient names in Korean when possible. Do not include utensils, containers, or non-food objects.',
+            },
+            {
+              inlineData: {
+                mimeType: image.type || 'image/jpeg',
+                data: base64,
+              },
+            },
+          ],
+        },
+      ],
+      config: {
+        responseMimeType: 'application/json',
+        responseSchema: ingredientSchema,
+        temperature: 0.2,
+        topK: 32,
+      },
+    });
+
+    const jsonText = response.text.trim();
+    const ingredients = JSON.parse(jsonText);
+
+    if (!Array.isArray(ingredients)) {
+      return [];
+    }
+
+    return ingredients.map((ingredient: string) => ingredient.trim()).filter(Boolean);
+  } catch (error) {
+    console.error('Gemini ingredient analysis failed', error);
+    throw new Error('error_vision_fetch');
+  }
+}
+
+async function analyzeWithExternalService(image: Blob): Promise<string[]> {
   if (!VISION_ENDPOINT) {
     throw new Error('error_vision_api_url');
   }
@@ -32,4 +114,19 @@ export async function analyzeIngredientsFromImage(image: Blob): Promise<string[]
   const ingredients = Array.isArray(data.ingredients) ? data.ingredients : [];
 
   return ingredients.map(ingredient => ingredient.trim()).filter(Boolean);
+}
+
+export async function analyzeIngredientsFromImage(image: Blob): Promise<string[]> {
+  if (VISION_ENDPOINT) {
+    try {
+      return await analyzeWithExternalService(image);
+    } catch (error) {
+      if (error instanceof Error && error.message === 'error_gemini_api_key') {
+        throw error;
+      }
+      console.warn('External vision service failed, falling back to Gemini.', error);
+    }
+  }
+
+  return analyzeWithGemini(image);
 }


### PR DESCRIPTION
## Summary
- add a Gemini 1.5 Flash-based fallback so ingredient extraction works without a dedicated vision endpoint
- reuse the GEMINI_API_KEY environment variable across Gemini services and update localized error guidance
- document the updated environment variable setup in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3734bb6408328897233e7699b4c73