### PR TITLE
Reimagine layout with category navigation and intro screen

### DIFF
--- a/camera-food-reciepe-main/components/BottomToolbar.tsx
+++ b/camera-food-reciepe-main/components/BottomToolbar.tsx
@@ -1,68 +1,55 @@
 import React from 'react';
-import { CameraIcon, SparklesIcon, PlusIcon, BookOpenIcon } from './icons';
-import { useLanguage } from '../context/LanguageContext';
 
-interface BottomToolbarProps {
-  onOpenCamera: () => void;
-  onSuggestRecipes: () => void;
-  onAddIngredient: () => void;
-  onOpenJournal: () => void;
+interface ToolbarAction {
+  key: string;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+  active?: boolean;
 }
 
-const BottomToolbar: React.FC<BottomToolbarProps> = ({
-  onOpenCamera,
-  onSuggestRecipes,
-  onAddIngredient,
-  onOpenJournal,
-}) => {
-  const { t } = useLanguage();
+interface BottomToolbarProps {
+  actions: ToolbarAction[];
+}
 
-  const actions = [
-    {
-      label: t('toolbarScan'),
-      description: t('toolbarScanHint'),
-      icon: <CameraIcon />, 
-      onClick: onOpenCamera,
-    },
-    {
-      label: t('toolbarSuggest'),
-      description: t('toolbarSuggestHint'),
-      icon: <SparklesIcon />, 
-      onClick: onSuggestRecipes,
-    },
-    {
-      label: t('toolbarAdd'),
-      description: t('toolbarAddHint'),
-      icon: <PlusIcon />, 
-      onClick: onAddIngredient,
-    },
-    {
-      label: t('toolbarJournal'),
-      description: t('toolbarJournalHint'),
-      icon: <BookOpenIcon />, 
-      onClick: onOpenJournal,
-    },
-  ];
+const BottomToolbar: React.FC<BottomToolbarProps> = ({ actions }) => {
+  if (!actions.length) {
+    return null;
+  }
 
   return (
     <nav className="fixed inset-x-4 bottom-6 z-40">
-      <div className="rounded-3xl bg-white/95 backdrop-blur shadow-2xl border border-gray-200 px-3 py-2 grid grid-cols-2 sm:grid-cols-4 gap-2">
-        {actions.map(action => (
-          <button
-            key={action.label}
-            type="button"
-            onClick={action.onClick}
-            className="group flex items-center gap-3 rounded-2xl px-3 py-3 transition hover:bg-gray-100"
-          >
-            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gray-100 text-brand-blue group-hover:bg-brand-blue group-hover:text-white transition">
-              {action.icon}
-            </span>
-            <span className="flex flex-col items-start">
-              <span className="text-sm font-semibold text-gray-800">{action.label}</span>
-              <span className="text-xs text-gray-500">{action.description}</span>
-            </span>
-          </button>
-        ))}
+      <div className="rounded-3xl border border-[#7CB7FF]/30 bg-[#E2F0FF]/90 backdrop-blur-xl px-4 py-3 shadow-[0_18px_40px_rgba(124,183,255,0.35)]">
+        <div className="grid grid-cols-4 gap-3">
+          {actions.map(action => (
+            <button
+              key={action.key}
+              type="button"
+              onClick={action.onClick}
+              aria-pressed={action.active}
+              className={`group flex flex-col items-center gap-2 rounded-2xl px-3 py-3 transition text-center ${
+                action.active
+                  ? 'bg-white shadow-lg shadow-[#7CB7FF]/30'
+                  : 'bg-white/40 hover:bg-white/70'
+              }`}
+            >
+              <span
+                className={`flex h-12 w-12 items-center justify-center rounded-2xl transition ${
+                  action.active
+                    ? 'bg-[#7CB7FF] text-white'
+                    : 'bg-[#EBF5FF] text-[#2A3B5F] group-hover:bg-[#7CB7FF]/90 group-hover:text-white'
+                }`}
+              >
+                {action.icon}
+              </span>
+              <span className={`text-sm font-semibold ${action.active ? 'text-[#1C2B4B]' : 'text-[#1C2B4B]/80'}`}>
+                {action.label}
+              </span>
+              <span className="text-[11px] text-[#1C2B4B]/60 leading-tight">{action.description}</span>
+            </button>
+          ))}
+        </div>
       </div>
     </nav>
   );

--- a/camera-food-reciepe-main/components/Header.tsx
+++ b/camera-food-reciepe-main/components/Header.tsx
@@ -2,35 +2,72 @@ import React from 'react';
 import { FridgeIcon } from './icons';
 import { useLanguage } from '../context/LanguageContext';
 
-const Header: React.FC = () => {
+type HeaderView = 'pantry' | 'recipes' | 'nutrition' | 'journal';
+
+interface HeaderProps {
+  activeView: HeaderView;
+  onNavigate: (view: HeaderView) => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ activeView, onNavigate }) => {
   const { language, setLanguage, t } = useLanguage();
 
+  const navItems: { key: HeaderView; label: string }[] = [
+    { key: 'pantry', label: t('navPantry') },
+    { key: 'recipes', label: t('navRecipes') },
+    { key: 'nutrition', label: t('navNutrition') },
+    { key: 'journal', label: t('navJournal') },
+  ];
+
   return (
-    <header className="bg-white/90 backdrop-blur border-b border-gray-100 sticky top-0 z-40">
-      <div className="container mx-auto px-4 py-4 md:py-5 max-w-5xl">
-        <div className="flex items-center justify-between gap-3">
+    <header className="sticky top-0 z-40 border-b border-[#7CB7FF]/30 bg-[#EBF5FF]/80 backdrop-blur-xl">
+      <div className="container mx-auto max-w-5xl px-4 py-4 md:py-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-3">
-            <FridgeIcon />
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#7CB7FF]/20 text-[#1F2E4C]">
+              <FridgeIcon />
+            </div>
             <div>
-              <h1 className="text-2xl md:text-3xl font-bold text-gray-800">Fridge Buddy</h1>
-              <p className="text-sm text-gray-500">{t('headerSubtitle')}</p>
+              <h1 className="text-2xl md:text-3xl font-black tracking-tight text-[#1C2B4B] uppercase">
+                냉장플래너
+              </h1>
+              <p className="text-sm text-[#1C2B4B]/70">{t('headerSubtitle')}</p>
             </div>
           </div>
-          <div className="flex items-center gap-4">
-            <div className="hidden sm:flex items-center gap-3 text-xs text-gray-400 uppercase tracking-widest">
+          <div className="flex items-center justify-between gap-3 md:justify-end">
+            <div className="hidden sm:flex items-center gap-3 text-[11px] uppercase tracking-[0.35em] text-[#1C2B4B]/60">
               <span>{t('headerScan')}</span>
-              <span className="w-1 h-1 rounded-full bg-gray-300"></span>
+              <span className="h-1 w-1 rounded-full bg-[#7CB7FF]/50" />
               <span>{t('headerPlan')}</span>
-              <span className="w-1 h-1 rounded-full bg-gray-300"></span>
+              <span className="h-1 w-1 rounded-full bg-[#7CB7FF]/50" />
               <span>{t('headerCook')}</span>
             </div>
             <button
               onClick={() => setLanguage(language === 'en' ? 'ko' : 'en')}
-              className="text-sm font-medium text-gray-600 hover:text-brand-blue transition-colors px-3 py-1 rounded-md bg-gray-100 hover:bg-gray-200"
+              className="rounded-full border border-[#7CB7FF]/40 bg-white/80 px-4 py-2 text-sm font-semibold text-[#1C2B4B] shadow-sm hover:bg-white"
             >
               {t('langToggle')}
             </button>
           </div>
+        </div>
+        <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {navItems.map(item => {
+            const isActive = activeView === item.key;
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => onNavigate(item.key)}
+                className={`rounded-2xl border px-4 py-3 text-sm font-semibold transition ${
+                  isActive
+                    ? 'border-[#7CB7FF] bg-white text-[#1C2B4B] shadow-lg shadow-[#7CB7FF]/25'
+                    : 'border-transparent bg-white/40 text-[#1C2B4B]/75 hover:bg-white/70 hover:border-[#7CB7FF]/40'
+                }`}
+              >
+                {item.label}
+              </button>
+            );
+          })}
         </div>
       </div>
     </header>

--- a/camera-food-reciepe-main/components/NutritionSummaryCard.tsx
+++ b/camera-food-reciepe-main/components/NutritionSummaryCard.tsx
@@ -21,27 +21,58 @@ const confidenceLabelKey: Record<
 
 const NutritionSummaryCard: React.FC<NutritionSummaryCardProps> = ({ summary, ingredients, onClear }) => {
   const { t } = useLanguage();
+  const macroTotal = summary.total.protein + summary.total.carbs + summary.total.fat;
+  const macroRows = [
+    {
+      key: 'protein' as const,
+      label: t('nutritionCardProtein'),
+      value: summary.total.protein,
+      accent: 'bg-emerald-500',
+      track: 'bg-emerald-100',
+      text: 'text-emerald-700',
+    },
+    {
+      key: 'carbs' as const,
+      label: t('nutritionCardCarbs'),
+      value: summary.total.carbs,
+      accent: 'bg-amber-500',
+      track: 'bg-amber-100',
+      text: 'text-amber-700',
+    },
+    {
+      key: 'fat' as const,
+      label: t('nutritionCardFat'),
+      value: summary.total.fat,
+      accent: 'bg-rose-500',
+      track: 'bg-rose-100',
+      text: 'text-rose-700',
+    },
+  ];
 
   return (
-    <section className="bg-white rounded-3xl shadow-xl border border-brand-blue/10 overflow-hidden">
-      <div className="bg-gradient-to-r from-brand-blue to-brand-blue/90 text-white p-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-        <div className="flex items-start gap-3">
-          <span className="inline-flex items-center justify-center h-12 w-12 rounded-2xl bg-white/20">
+    <section className="rounded-[36px] border border-[#7CB7FF]/30 bg-white/90 backdrop-blur-xl shadow-[0_28px_60px_rgba(124,183,255,0.22)] overflow-hidden">
+      <div className="relative bg-[#7CB7FF] text-white p-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div className="pointer-events-none absolute -top-20 -left-24 h-48 w-48 rounded-full bg-[#E2F0FF]/40 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-16 -right-16 h-40 w-40 rounded-full bg-[#EBF5FF]/40 blur-3xl" />
+        <div className="relative flex items-start gap-3">
+          <span className="inline-flex items-center justify-center h-12 w-12 rounded-2xl bg-white/25 text-[#1C2B4B]">
             <SparklesIcon />
           </span>
-          <div>
-            <p className="text-xs uppercase tracking-[0.2em] text-white/60 font-semibold">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.35em] text-white/75 font-semibold">
               {t('nutritionCardTagline')}
             </p>
-            <h2 className="text-2xl font-bold leading-tight">{t('nutritionCardTitle')}</h2>
-            <p className="text-sm text-white/80">{t('nutritionCardSubtitle')}</p>
+            <h2 className="text-2xl font-bold leading-tight drop-shadow-[0_10px_18px_rgba(28,43,75,0.25)]">
+              {t('nutritionCardTitle')}
+            </h2>
+            <p className="text-sm text-white/85 max-w-xl">{t('nutritionCardSubtitle')}</p>
           </div>
         </div>
         {onClear && (
           <button
             type="button"
             onClick={onClear}
-            className="text-xs font-semibold uppercase tracking-widest rounded-full px-4 py-2 bg-white/10 hover:bg-white/20 transition"
+            className="relative text-xs font-semibold uppercase tracking-[0.35em] rounded-full px-4 py-2 bg-white/20 text-white hover:bg-white/30 transition"
           >
             {t('nutritionCardDismiss')}
           </button>
@@ -49,11 +80,11 @@ const NutritionSummaryCard: React.FC<NutritionSummaryCardProps> = ({ summary, in
       </div>
       <div className="p-6 space-y-6">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-brand-blue/5 rounded-2xl p-4 flex flex-col">
-            <span className="text-xs font-semibold uppercase tracking-wide text-brand-blue/70">
+          <div className="rounded-2xl border border-[#7CB7FF]/30 bg-[#EBF5FF] p-4 flex flex-col">
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#1C2B4B]/70">
               {t('nutritionCardCalories')}
             </span>
-            <span className="text-2xl font-bold text-brand-blue mt-1">
+            <span className="text-2xl font-bold text-[#1C2B4B] mt-1">
               {formatMacro(summary.total.calories, 'kcal')}
             </span>
           </div>
@@ -83,15 +114,52 @@ const NutritionSummaryCard: React.FC<NutritionSummaryCardProps> = ({ summary, in
           </div>
         </div>
 
-        <div className="bg-gray-50 border border-gray-200 rounded-2xl p-5 space-y-4">
+        {macroTotal > 0 && (
+          <div className="bg-white border border-[#E2F0FF] rounded-2xl p-5 space-y-4">
+            <div className="flex flex-col gap-1">
+              <h3 className="text-sm font-semibold text-[#1C2B4B]">
+                {t('nutritionCardMacroSplitTitle')}
+              </h3>
+              <p className="text-xs text-[#1C2B4B]/60">{t('nutritionCardMacroSplitHint')}</p>
+            </div>
+            <div className="space-y-3">
+              {macroRows.map(row => {
+                const percent = Math.round((row.value / macroTotal) * 100);
+                return (
+                  <div key={row.key} className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <span className={`text-xs font-semibold uppercase tracking-wide ${row.text}`}>
+                        {row.label}
+                      </span>
+                      <span className="text-sm font-semibold text-[#1C2B4B]">
+                        {formatMacro(row.value, 'g')}
+                      </span>
+                    </div>
+                    <div className={`h-2 w-full rounded-full ${row.track}`}>
+                      <div
+                        className={`h-full rounded-full ${row.accent}`}
+                        style={{ width: `${percent}%` }}
+                      />
+                    </div>
+                    <p className="text-[11px] text-[#1C2B4B]/60">
+                      {t('nutritionCardMacroPercent', { percent })}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <div className="bg-[#EBF5FF]/60 border border-[#E2F0FF] rounded-2xl p-5 space-y-4">
           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
             <div>
-              <h3 className="text-sm font-semibold text-gray-700">
+              <h3 className="text-sm font-semibold text-[#1C2B4B]">
                 {t('nutritionCardDetectedLabel', { count: summary.detectedCount })}
               </h3>
-              <p className="text-xs text-gray-500">{ingredients.join(', ')}</p>
+              <p className="text-xs text-[#1C2B4B]/60">{ingredients.join(', ')}</p>
             </div>
-            <span className="inline-flex items-center rounded-full bg-gray-200 px-3 py-1 text-[11px] font-semibold uppercase tracking-widest text-gray-600">
+            <span className="inline-flex items-center rounded-full bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-[#1C2B4B]/70">
               {t('nutritionCardServingHint')}
             </span>
           </div>
@@ -100,11 +168,11 @@ const NutritionSummaryCard: React.FC<NutritionSummaryCardProps> = ({ summary, in
             {summary.breakdown.map(entry => (
               <div
                 key={`${entry.ingredient}-${entry.confidence}`}
-                className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 bg-white rounded-xl border border-gray-200 p-4"
+                className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 bg-white rounded-xl border border-[#E2F0FF] p-4 shadow-sm"
               >
                 <div>
-                  <p className="text-sm font-semibold text-gray-800 capitalize">{entry.ingredient}</p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-sm font-semibold text-[#1C2B4B] capitalize">{entry.ingredient}</p>
+                  <p className="text-xs text-[#1C2B4B]/60">
                     {t('nutritionCardBreakdown', {
                       protein: formatMacro(entry.profile.protein, 'g'),
                       carbs: formatMacro(entry.profile.carbs, 'g'),
@@ -113,10 +181,10 @@ const NutritionSummaryCard: React.FC<NutritionSummaryCardProps> = ({ summary, in
                   </p>
                 </div>
                 <div className="flex flex-col items-end">
-                  <span className="text-sm font-bold text-brand-blue">
+                  <span className="text-sm font-bold text-[#1C2B4B]">
                     {formatMacro(entry.profile.calories, 'kcal')}
                   </span>
-                  <span className="text-[11px] font-semibold uppercase tracking-widest text-gray-400">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.35em] text-[#1C2B4B]/40">
                     {t(confidenceLabelKey[entry.confidence])}
                   </span>
                 </div>

--- a/camera-food-reciepe-main/locales/en.ts
+++ b/camera-food-reciepe-main/locales/en.ts
@@ -4,6 +4,36 @@ export const headerPlan = 'Plan';
 export const headerCook = 'Cook';
 export const langToggle = '한국어';
 
+export const introHeadline = '냉장플래너';
+export const introBreath = 'Deep breath in, ideas out';
+export const introDescription =
+  'Turn your fridge into a planning studio. Capture ingredients, switch between recipe ideas and nutrition insights, and cook with confidence.';
+export const introPrimaryAction = 'Start planning';
+export const introSecondaryAction = 'Scan my fridge';
+
+export const navPantry = 'Pantry';
+export const navRecipes = 'Recipes';
+export const navNutrition = 'Nutrition';
+export const navJournal = 'Journal';
+
+export const pantryViewTagline = 'Ingredient control centre';
+export const recipesViewTagline = 'Idea lab';
+export const recipesViewTitle = 'Fresh dishes built around your fridge';
+export const recipesViewSubtitle =
+  'Select ingredients, jump into recipe suggestions, and see your nutrition snapshot whenever you need it.';
+export const recipesViewSuggestButton = 'Refresh ideas';
+export const recipesViewScanButton = 'Scan new photo';
+export const recipesViewNutritionButton = 'View nutrition';
+export const recipesViewOpenModal = 'OPEN RECIPE LIST';
+export const recipesViewEmpty = 'Add or scan ingredients to unlock smart recipe matches.';
+export const recipesViewMore = 'Plus {{count}} more recipes waiting inside the suggestions panel.';
+export const nutritionEmptyTitle = 'No nutrition snapshot yet';
+export const nutritionEmptyDescription =
+  'Scan your fridge or choose a few ingredients to generate a calorie and macro estimate instantly.';
+export const nutritionEmptyRecipes = 'Open recipe ideas';
+export const nutritionEmptyScan = 'Scan ingredients';
+export const journalViewTagline = 'Memory vault';
+
 export const heroSectionTagline = 'Fridge-friendly meal ideas';
 export const heroSectionTitle = "Snap your fridge or type your ingredients. We'll handle the dinner inspiration.";
 export const heroSectionDescription = "Get tailored recipe ideas and cooking videos without juggling multiple apps. You focus on cooking—we'll find what fits your kitchen.";
@@ -103,6 +133,9 @@ export const nutritionCardFat = 'Fat';
 export const nutritionCardDetectedLabel = 'Detected ingredients ({{count}})';
 export const nutritionCardServingHint = '1 serving estimate';
 export const nutritionCardBreakdown = 'P: {{protein}} · C: {{carbs}} · F: {{fat}}';
+export const nutritionCardMacroSplitTitle = 'Macro balance at a glance';
+export const nutritionCardMacroSplitHint = 'Percent of total macros';
+export const nutritionCardMacroPercent = '{{percent}}% of macros';
 export const nutritionConfidenceHigh = 'High confidence';
 export const nutritionConfidenceMedium = 'Medium confidence';
 export const nutritionConfidenceLow = 'Estimated';

--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -4,6 +4,36 @@ export const headerPlan = '계획';
 export const headerCook = '요리';
 export const langToggle = 'English';
 
+export const introHeadline = '냉장플래너';
+export const introBreath = '심호흡하고 시작해볼까요';
+export const introDescription =
+  '냉장고 속 재료를 촬영하거나 선택해서 레시피, 영양 정보, 나만의 기록을 한 번에 관리해보세요.';
+export const introPrimaryAction = '시작하기';
+export const introSecondaryAction = '냉장고 스캔하기';
+
+export const navPantry = '재료';
+export const navRecipes = '레시피';
+export const navNutrition = '영양';
+export const navJournal = '기록';
+
+export const pantryViewTagline = '카테고리별 정리';
+export const recipesViewTagline = '레시피 연구실';
+export const recipesViewTitle = '냉장고 재료로 오늘의 메뉴 찾기';
+export const recipesViewSubtitle =
+  '선택한 재료로 레시피를 추천받고, 필요할 때마다 영양 정보를 함께 확인하세요.';
+export const recipesViewSuggestButton = '추천 새로고침';
+export const recipesViewScanButton = '새로 스캔하기';
+export const recipesViewNutritionButton = '영양 보기';
+export const recipesViewOpenModal = '전체 레시피 보기';
+export const recipesViewEmpty = '재료를 추가하거나 스캔하면 추천을 받을 수 있어요.';
+export const recipesViewMore = '추천 창에서 {{count}}개의 레시피를 더 확인할 수 있어요.';
+export const nutritionEmptyTitle = '아직 영양 요약이 없어요';
+export const nutritionEmptyDescription =
+  '재료를 선택하거나 냉장고를 스캔하면 칼로리와 영양 균형을 바로 계산해드려요.';
+export const nutritionEmptyRecipes = '레시피 추천 열기';
+export const nutritionEmptyScan = '재료 스캔하기';
+export const journalViewTagline = '요리 기록장';
+
 export const heroSectionTagline = '냉장고 속 재료로 만드는 식사 아이디어';
 export const heroSectionTitle = '냉장고를 촬영하거나 재료를 입력하세요. 저녁 메뉴는 저희가 제안해 드릴게요.';
 export const heroSectionDescription = '여러 앱을 오갈 필요 없이 맞춤 레시피 아이디어와 요리 영상을 받아보세요. 당신은 요리에만 집중하세요.';
@@ -103,6 +133,9 @@ export const nutritionCardFat = '지방';
 export const nutritionCardDetectedLabel = '감지된 재료 ({{count}}개)';
 export const nutritionCardServingHint = '1인분 기준';
 export const nutritionCardBreakdown = '단백질 {{protein}} · 탄수화물 {{carbs}} · 지방 {{fat}}';
+export const nutritionCardMacroSplitTitle = '한눈에 보는 영양 비율';
+export const nutritionCardMacroSplitHint = '3대 영양소 비중 (%)';
+export const nutritionCardMacroPercent = '전체 영양소의 {{percent}}%';
 export const nutritionConfidenceHigh = '신뢰도 높음';
 export const nutritionConfidenceMedium = '신뢰도 보통';
 export const nutritionConfidenceLow = '대략적인 추정';


### PR DESCRIPTION
## Summary
- add a 3D-styled "냉장플래너" intro screen and reorganize the app into palette-driven views for pantry, recipes, nutrition, and journal navigation
- refresh the header and floating toolbar to act as category selectors with #EBF5FF, #E2F0FF, and #7CB7FF treatments
- update the nutrition summary card styling and add new locale strings to support the redesigned flows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e288a0488328a9981b3c1e30ae57