### PR TITLE
Adjust nutrition flow and add manual ingredient input

### DIFF
--- a/camera-food-reciepe-main/locales/en.ts
+++ b/camera-food-reciepe-main/locales/en.ts
@@ -53,6 +53,11 @@ export const pantrySectionScanButton = 'Scan fridge';
 export const pantrySectionNutritionButton = 'Open nutrition';
 export const pantryEmptyTitle = 'No scans yet';
 export const pantryEmptyDescription = 'Capture a photo of your fridge to populate this list.';
+export const pantryManualInputTitle = 'Type your ingredients manually';
+export const pantryManualInputPlaceholder = 'e.g. chicken, garlic, rice';
+export const pantryManualInputHint = 'Separate each ingredient with commas or new lines.';
+export const pantryManualInputSubmit = 'Use these ingredients';
+export const pantryManualInputError = 'Please enter at least one ingredient.';
 
 export const itemCardAdded = 'Detected';
 export const itemCardRecently = 'recently';

--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -53,6 +53,11 @@ export const pantrySectionScanButton = '냉장고 스캔';
 export const pantrySectionNutritionButton = '영양 패널 열기';
 export const pantryEmptyTitle = '아직 스캔 기록이 없어요';
 export const pantryEmptyDescription = '냉장고를 촬영하면 인식된 재료가 여기에 표시돼요.';
+export const pantryManualInputTitle = '직접 재료 입력하기';
+export const pantryManualInputPlaceholder = '예: 닭가슴살, 마늘, 밥';
+export const pantryManualInputHint = '쉼표 또는 줄바꿈으로 재료를 구분해주세요.';
+export const pantryManualInputSubmit = '이 재료로 활용하기';
+export const pantryManualInputError = '최소 한 가지 재료를 입력해주세요.';
 
 export const itemCardAdded = '감지됨';
 export const itemCardRecently = '최근';


### PR DESCRIPTION
## Summary
- stop populating the nutrition snapshot when scanning fridge ingredients
- add a manual ingredient entry form so users can type the items they have
- add supporting translations for the new pantry form in English and Korean

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f811f804832891f0c15f8dfa2d56