### PR TITLE
Handle Gemini response text safely

### DIFF
--- a/camera-food-reciepe-main/services/geminiService.ts
+++ b/camera-food-reciepe-main/services/geminiService.ts
@@ -60,8 +60,21 @@ export async function getRecipeSuggestions(ingredients: string[]): Promise<Recip
             },
         });
 
-        const jsonText = response.text.trim();
-        const recipes: Recipe[] = JSON.parse(jsonText);
+        let jsonText: string | undefined;
+
+        if (typeof response.output_text === 'string') {
+            jsonText = response.output_text;
+        } else if (response.response && typeof response.response.text === 'function') {
+            jsonText = await response.response.text();
+        }
+
+        const trimmedJson = jsonText?.trim();
+
+        if (!trimmedJson) {
+            throw new Error('error_gemini_fetch');
+        }
+
+        const recipes: Recipe[] = JSON.parse(trimmedJson);
         return recipes.map(recipe => ({
             ...recipe,
             instructions: Array.isArray(recipe.instructions)

--- a/camera-food-reciepe-main/services/visionService.ts
+++ b/camera-food-reciepe-main/services/visionService.ts
@@ -73,8 +73,21 @@ async function analyzeWithGemini(image: Blob): Promise<string[]> {
       },
     });
 
-    const jsonText = response.text.trim();
-    const ingredients = JSON.parse(jsonText);
+    let jsonText: string | undefined;
+
+    if (typeof response.output_text === 'string') {
+      jsonText = response.output_text;
+    } else if (response.response && typeof response.response.text === 'function') {
+      jsonText = await response.response.text();
+    }
+
+    const trimmedJson = jsonText?.trim();
+
+    if (!trimmedJson) {
+      throw new Error('error_vision_fetch');
+    }
+
+    const ingredients = JSON.parse(trimmedJson);
 
     if (!Array.isArray(ingredients)) {
       return [];


### PR DESCRIPTION
## Summary
- ensure the vision Gemini integration reads `output_text` or the raw response body before parsing JSON
- add the same `output_text` guard for recipe suggestions so empty or invalid payloads surface an error

## Testing
- npm run dev *(not fully verified in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d77163daf88328917b0074fc1dadb6