### PR TITLE
Fix Gemini response parsing

### DIFF
--- a/camera-food-reciepe-main/services/geminiService.ts
+++ b/camera-food-reciepe-main/services/geminiService.ts
@@ -60,12 +60,13 @@ export async function getRecipeSuggestions(ingredients: string[]): Promise<Recip
             },
         });
 
-        let jsonText: string | undefined;
+        let jsonText: string | undefined = response.text;
 
-        if (typeof response.output_text === 'string') {
-            jsonText = response.output_text;
-        } else if (response.response && typeof response.response.text === 'function') {
-            jsonText = await response.response.text();
+        if (!jsonText) {
+            const fallback = (response as { output_text?: string | undefined }).output_text;
+            if (typeof fallback === 'string') {
+                jsonText = fallback;
+            }
         }
 
         const trimmedJson = jsonText?.trim();


### PR DESCRIPTION
## Summary
- prefer the Gemini SDK response.text accessor when parsing recipe results
- keep the existing guard rails while falling back to legacy output_text strings when needed

## Testing
- npm run build
- node /tmp/run-recipe-test.cjs

------
https://chatgpt.com/codex/tasks/task_e_68d777140e2c8328bad5d11778b0d343