### PR TITLE
Handle Gemini response text fallback

### DIFF
--- a/camera-food-reciepe-main/services/visionService.ts
+++ b/camera-food-reciepe-main/services/visionService.ts
@@ -75,10 +75,10 @@ async function analyzeWithGemini(image: Blob): Promise<string[]> {
 
     let jsonText: string | undefined;
 
-    if (typeof response.output_text === 'string') {
+    if (typeof response.text === 'string') {
+      jsonText = response.text;
+    } else if (typeof response.output_text === 'string') {
       jsonText = response.output_text;
-    } else if (response.response && typeof response.response.text === 'function') {
-      jsonText = await response.response.text();
     }
 
     const trimmedJson = jsonText?.trim();


### PR DESCRIPTION
## Summary
- update Gemini ingredient parsing to prioritize the new `response.text` payload while retaining the empty-response guard

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68d7771314508328be9aa565a11af668