### PR TITLE
Align vision fallback with Gemini 2.5

### DIFF
--- a/camera-food-reciepe-main/README.md
+++ b/camera-food-reciepe-main/README.md
@@ -22,9 +22,10 @@ index a4812bcc3d031391576f28ff39962d87816fa3b5..34646da0c8082de1c89b719a08de0b4d
    `npm install`
 2. Set the following environment variables in [.env.local](.env.local):
    - `GEMINI_API_KEY` for your Gemini access token. This key powers both text recipes and the built-in vision fallback.
+   - `GEMINI_VISION_MODEL` (optional) to override the default `gemini-2.5-flash` model used for image analysis fallback.
    - `YOUTUBE_API_KEY` for fetching complementary cooking videos via the YouTube Data API.
    - `VISION_API_URL` (optional) pointing to the HTTPS endpoint of your custom image analysis service.
    - `VISION_API_KEY` (optional) if your service requires bearer-token authentication.
-   - If you do not provide a `VISION_API_URL`, the app will automatically analyze photos with Gemini 1.5 Flash using the `GEMINI_API_KEY`.
+   - If you do not provide a `VISION_API_URL`, the app will automatically analyze photos with Gemini 2.5 Flash using the `GEMINI_API_KEY`.
 3. Run the app:
    `npm run dev`

--- a/camera-food-reciepe-main/services/visionService.ts
+++ b/camera-food-reciepe-main/services/visionService.ts
@@ -5,6 +5,9 @@ const VISION_API_KEY = process.env.VISION_API_KEY as string | undefined;
 const GEMINI_API_KEY =
   (process.env.GEMINI_API_KEY as string | undefined) ?? (process.env.API_KEY as string | undefined);
 
+const GEMINI_VISION_MODEL =
+  (process.env.GEMINI_VISION_MODEL as string | undefined) ?? 'gemini-2.5-flash';
+
 const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
 
 const ingredientSchema = {
@@ -47,7 +50,7 @@ async function analyzeWithGemini(image: Blob): Promise<string[]> {
     const base64 = arrayBufferToBase64(arrayBuffer);
 
     const response = await ai.models.generateContent({
-      model: 'gemini-1.5-flash',
+      model: GEMINI_VISION_MODEL,
       contents: [
         {
           role: 'user',


### PR DESCRIPTION
## Summary
- add a configurable `GEMINI_VISION_MODEL` fallback that defaults to `gemini-2.5-flash`
- update the vision fallback documentation to reflect the Gemini 2.5 default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d779ec54c8832897e6910457b6247e