### PR TITLE
Add validated recipe link lookups

### DIFF
--- a/camera-food-reciepe-main/README.md
+++ b/camera-food-reciepe-main/README.md
@@ -25,6 +25,13 @@ index a4812bcc3d031391576f28ff39962d87816fa3b5..34646da0c8082de1c89b719a08de0b4d
    - `YOUTUBE_API_KEY` for fetching complementary cooking videos via the YouTube Data API.
    - `VISION_API_URL` (optional) pointing to the HTTPS endpoint of your custom image analysis service.
    - `VISION_API_KEY` (optional) if your service requires bearer-token authentication.
+   - `VITE_SPOONACULAR_API_KEY` (optional) for direct recipe matches from the Spoonacular API. Without this key the app will fall back to other providers.
    - If you do not provide a `VISION_API_URL`, the app will automatically analyze photos with Gemini 1.5 Flash using the `GEMINI_API_KEY`.
 3. Run the app:
    `npm run dev`
+
+### Recipe link providers
+
+- **에디터 추천**: Uses a curated mapping of popular Korean recipes to provide fast, high-confidence links.
+- **TheMealDB**: Fetches free recipe metadata via the public [TheMealDB](https://www.themealdb.com/api.php) API. No key is required.
+- **Spoonacular** *(optional)*: When `VITE_SPOONACULAR_API_KEY` is supplied, the modal validates a direct source URL using Spoonacular's `complexSearch` endpoint. Set this key in `.env.local` if you want richer, English-language results.

--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -106,6 +106,9 @@ export const recipeModalMatchedIngredientsLabel = '이미 보유';
 export const recipeModalBadgeReady = '바로 요리 가능';
 export const recipeModalBadgeMissing = '{{count}}개 더 필요';
 export const recipeModalSearchProvidersLabel = '다음에서 자세한 레시피 찾기:';
+export const recipeModalProviderLoading = '검증된 레시피 링크를 불러오는 중이에요...';
+export const recipeModalProviderError = '{{provider}}에서 바로 열 수 있는 링크를 찾지 못했어요.';
+export const recipeModalProviderErrorWithReason = '{{provider}}에서 바로 열 수 있는 링크를 찾지 못했어요. {{reason}}';
 export const recipeModalRecipeNutritionHint = '이 레시피에 맞춘 영양 추정을 바로 확인해보세요.';
 export const recipeModalRecipeNutritionButton = '이 레시피 영양 보기';
 

--- a/camera-food-reciepe-main/services/recipeLinkService.ts
+++ b/camera-food-reciepe-main/services/recipeLinkService.ts
@@ -1,0 +1,260 @@
+export interface RecipeProviderLinkSuccess {
+  provider: string;
+  status: 'success';
+  title: string;
+  url: string;
+}
+
+export interface RecipeProviderLinkError {
+  provider: string;
+  status: 'error';
+  message?: string;
+}
+
+export type RecipeProviderLinkResult = RecipeProviderLinkSuccess | RecipeProviderLinkError;
+
+type ProviderFetcher = (
+  recipeName: string,
+  ingredients: string[],
+  signal?: AbortSignal
+) => Promise<RecipeProviderLinkResult>;
+
+interface RecipeProviderDefinition {
+  name: string;
+  fetchLink: ProviderFetcher;
+}
+
+const curatedRecipes: Array<{
+  matches: string[];
+  title: string;
+  url: string;
+}> = [
+  {
+    matches: ['김치찌개', 'kimchi'],
+    title: '백종원 김치찌개 레시피',
+    url: 'https://www.10000recipe.com/recipe/6893793',
+  },
+  {
+    matches: ['된장찌개', 'soybean paste stew', 'doenjang'],
+    title: '전통 된장찌개 황금레시피',
+    url: 'https://www.10000recipe.com/recipe/6864809',
+  },
+  {
+    matches: ['bulgogi', '불고기'],
+    title: '소불고기 양념 비법',
+    url: 'https://www.10000recipe.com/recipe/6901913',
+  },
+];
+
+const curatedProvider: RecipeProviderDefinition = {
+  name: '에디터 추천',
+  fetchLink: async (recipeName, ingredients) => {
+    const normalizedName = recipeName.trim().toLowerCase();
+    const normalizedIngredients = ingredients.map(ingredient => ingredient.trim().toLowerCase());
+
+    const match = curatedRecipes.find(entry => {
+      return entry.matches.some(keyword => {
+        const normalizedKeyword = keyword.toLowerCase();
+        return (
+          normalizedName.includes(normalizedKeyword) ||
+          normalizedIngredients.some(ingredient => ingredient.includes(normalizedKeyword))
+        );
+      });
+    });
+
+    if (!match) {
+      return {
+        provider: curatedProvider.name,
+        status: 'error',
+        message: '등록된 링크가 아직 없어요.',
+      };
+    }
+
+    return {
+      provider: curatedProvider.name,
+      status: 'success',
+      title: match.title,
+      url: match.url,
+    };
+  },
+};
+
+const themealDbProvider: RecipeProviderDefinition = {
+  name: 'TheMealDB',
+  fetchLink: async (recipeName, ingredients, signal) => {
+    const query = recipeName.trim() || ingredients[0] || '';
+    if (!query) {
+      return {
+        provider: themealDbProvider.name,
+        status: 'error',
+        message: '검색할 키워드가 부족해요.',
+      };
+    }
+
+    const response = await fetch(
+      `https://www.themealdb.com/api/json/v1/1/search.php?s=${encodeURIComponent(query)}`,
+      { signal }
+    );
+
+    if (!response.ok) {
+      throw new Error('TheMealDB 응답이 올바르지 않아요.');
+    }
+
+    const data = (await response.json()) as {
+      meals?: Array<{
+        strMeal: string;
+        strSource?: string | null;
+        strYoutube?: string | null;
+      }>;
+    };
+
+    if (!data.meals || data.meals.length === 0) {
+      return {
+        provider: themealDbProvider.name,
+        status: 'error',
+        message: '일치하는 레시피를 찾지 못했어요.',
+      };
+    }
+
+    const [meal] = data.meals;
+    const candidateUrl = meal.strSource?.trim() || meal.strYoutube?.trim();
+
+    if (!candidateUrl) {
+      return {
+        provider: themealDbProvider.name,
+        status: 'error',
+        message: '응답에 링크 정보가 없어요.',
+      };
+    }
+
+    return {
+      provider: themealDbProvider.name,
+      status: 'success',
+      title: meal.strMeal,
+      url: candidateUrl,
+    };
+  },
+};
+
+const spoonacularProvider: RecipeProviderDefinition = {
+  name: 'Spoonacular',
+  fetchLink: async (recipeName, ingredients, signal) => {
+    const apiKey = import.meta.env.VITE_SPOONACULAR_API_KEY;
+
+    if (!apiKey) {
+      return {
+        provider: spoonacularProvider.name,
+        status: 'error',
+        message: 'VITE_SPOONACULAR_API_KEY를 설정해주세요.',
+      };
+    }
+
+    const url = new URL('https://api.spoonacular.com/recipes/complexSearch');
+    url.searchParams.set('query', recipeName);
+    url.searchParams.set('number', '1');
+    url.searchParams.set('instructionsRequired', 'true');
+    url.searchParams.set('addRecipeInformation', 'true');
+
+    if (ingredients.length > 0) {
+      url.searchParams.set(
+        'includeIngredients',
+        ingredients
+          .map(ingredient => ingredient.trim())
+          .filter(Boolean)
+          .slice(0, 5)
+          .join(',')
+      );
+    }
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
+      signal,
+    });
+
+    if (!response.ok) {
+      throw new Error('Spoonacular API 호출에 실패했어요.');
+    }
+
+    const data = (await response.json()) as {
+      results?: Array<{
+        title: string;
+        sourceUrl?: string;
+        spoonacularSourceUrl?: string;
+      }>;
+    };
+
+    const recipe = data.results?.[0];
+
+    if (!recipe) {
+      return {
+        provider: spoonacularProvider.name,
+        status: 'error',
+        message: '일치하는 레시피가 없어요.',
+      };
+    }
+
+    const link = recipe.sourceUrl || recipe.spoonacularSourceUrl;
+
+    if (!link) {
+      return {
+        provider: spoonacularProvider.name,
+        status: 'error',
+        message: '제공된 링크가 없어요.',
+      };
+    }
+
+    return {
+      provider: spoonacularProvider.name,
+      status: 'success',
+      title: recipe.title,
+      url: link,
+    };
+  },
+};
+
+const recipeProviders: RecipeProviderDefinition[] = [curatedProvider, themealDbProvider, spoonacularProvider];
+
+export const recipeProviderNames = recipeProviders.map(provider => provider.name);
+
+const isAbortError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  return (
+    // DOMException in browsers
+    ('name' in error && (error as { name?: string }).name === 'AbortError') ||
+    // DOMException polyfill
+    Object.prototype.toString.call(error) === '[object DOMException]' &&
+      'code' in error &&
+      (error as { code?: number }).code === 20
+  );
+};
+
+export const fetchRecipeLinks = async (
+  recipeName: string,
+  ingredients: string[],
+  signal?: AbortSignal
+): Promise<RecipeProviderLinkResult[]> => {
+  const lookups = recipeProviders.map(async provider => {
+    try {
+      return await provider.fetchLink(recipeName, ingredients, signal);
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+
+      return {
+        provider: provider.name,
+        status: 'error',
+        message:
+          error instanceof Error ? error.message : '알 수 없는 오류가 발생했어요.',
+      } satisfies RecipeProviderLinkError;
+    }
+  });
+
+  return Promise.all(lookups);
+};


### PR DESCRIPTION
## Summary
- add a recipe link service that queries curated matches, TheMealDB, and Spoonacular for direct recipe URLs
- update the recipe modal to fetch provider links asynchronously, render validated titles, and surface per-provider errors
- translate new status copy and document the Spoonacular API key requirement in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d78365bf54832881796365fc9042f0