### PR TITLE
feat: add generated previews to recipe journal

### DIFF
--- a/camera-food-reciepe-main/components/RecipeJournal.tsx
+++ b/camera-food-reciepe-main/components/RecipeJournal.tsx
@@ -1,27 +1,95 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { RecipeMemory } from '../types';
-import { BookOpenIcon, FlameIcon, TrashIcon, ClipboardIcon } from './icons';
+import { BookOpenIcon, FlameIcon, TrashIcon, ClipboardIcon, MoreVerticalIcon } from './icons';
 import { useLanguage } from '../context/LanguageContext';
+
+const dataUrlToBlob = (dataUrl: string): Blob => {
+  const [metadata, base64Data] = dataUrl.split(',', 2);
+  if (!metadata || !base64Data) {
+    throw new Error('Invalid data URL');
+  }
+
+  const mimeMatch = metadata.match(/data:(.*?);base64/);
+  const mimeType = mimeMatch ? mimeMatch[1] : 'image/png';
+  const binary = atob(base64Data);
+  const length = binary.length;
+  const buffer = new Uint8Array(length);
+  for (let index = 0; index < length; index += 1) {
+    buffer[index] = binary.charCodeAt(index);
+  }
+  return new Blob([buffer], { type: mimeType });
+};
+
+const hashString = (value: string) => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+};
+
+const placeholderPalettes: [string, string, string][] = [
+  ['#FDE68A', '#FDBA74', '#F97316'],
+  ['#DBEAFE', '#A5B4FC', '#6366F1'],
+  ['#E0F2FE', '#7DD3FC', '#0EA5E9'],
+  ['#FCE7F3', '#F9A8D4', '#EC4899'],
+  ['#DCFCE7', '#86EFAC', '#16A34A'],
+  ['#FFE4E6', '#FDA4AF', '#F43F5E'],
+  ['#E2E8F0', '#CBD5F5', '#64748B'],
+];
+
+const buildPlaceholderStyle = (seed: string) => {
+  const palette = placeholderPalettes[hashString(seed) % placeholderPalettes.length];
+  const accentIndex = hashString(`${seed}-accent`) % palette.length;
+  const accent = palette[accentIndex];
+  return {
+    style: {
+      backgroundImage: `radial-gradient(circle at 0% 0%, ${palette[0]} 0%, transparent 70%), radial-gradient(circle at 100% 100%, ${palette[1]} 0%, transparent 72%), linear-gradient(135deg, ${palette[0]} 0%, ${palette[2]} 100%)`,
+    } as React.CSSProperties,
+    accent,
+  };
+};
+
+const getInitials = (name: string) => {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return '??';
+  }
+
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return `${parts[0][0] ?? ''}${parts[1][0] ?? ''}`.toUpperCase();
+};
 
 interface RecipeJournalProps {
   entries: RecipeMemory[];
   onUpdate: (id: string, updates: Partial<RecipeMemory>) => void;
   onDelete: (id: string) => void;
+  onRegeneratePreview: (id: string) => void;
   onMarkCooked: (id: string) => void;
   onOpenDetails: (id: string) => void;
   highlightedId?: string | null;
+  pendingPreviewIds: ReadonlySet<string>;
 }
 
 const RecipeJournal: React.FC<RecipeJournalProps> = ({
   entries,
   onUpdate,
   onDelete,
+  onRegeneratePreview,
   onMarkCooked,
   onOpenDetails,
   highlightedId,
+  pendingPreviewIds,
 }) => {
   const { t } = useLanguage();
   const [draftNotes, setDraftNotes] = useState<Record<string, string>>({});
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({});
+  const previewObjectUrlCache = useRef<Map<string, { source: string; url: string }>>(new Map());
 
   useEffect(() => {
     setDraftNotes(prev => {
@@ -44,6 +112,92 @@ const RecipeJournal: React.FC<RecipeJournalProps> = ({
     });
   }, [entries]);
 
+  useEffect(() => {
+    const nextUrls: Record<string, string> = {};
+    const seen = new Set<string>();
+
+    entries.forEach(entry => {
+      seen.add(entry.id);
+      const source = entry.journalPreviewImage;
+      const cached = previewObjectUrlCache.current.get(entry.id);
+
+      if (!source) {
+        if (cached) {
+          URL.revokeObjectURL(cached.url);
+          previewObjectUrlCache.current.delete(entry.id);
+        }
+        return;
+      }
+
+      if (/^(https?:|blob:)/i.test(source)) {
+        if (cached) {
+          URL.revokeObjectURL(cached.url);
+          previewObjectUrlCache.current.delete(entry.id);
+        }
+        nextUrls[entry.id] = source;
+        return;
+      }
+
+      if (/^data:/i.test(source)) {
+        if (!cached || cached.source !== source) {
+          if (cached) {
+            URL.revokeObjectURL(cached.url);
+          }
+          try {
+            const blob = dataUrlToBlob(source);
+            const objectUrl = URL.createObjectURL(blob);
+            previewObjectUrlCache.current.set(entry.id, { source, url: objectUrl });
+            nextUrls[entry.id] = objectUrl;
+          } catch (error) {
+            console.error('Failed to create preview object URL', error);
+            previewObjectUrlCache.current.delete(entry.id);
+          }
+        } else {
+          nextUrls[entry.id] = cached.url;
+        }
+        return;
+      }
+
+      if (cached) {
+        URL.revokeObjectURL(cached.url);
+        previewObjectUrlCache.current.delete(entry.id);
+      }
+      nextUrls[entry.id] = source;
+    });
+
+    Array.from(previewObjectUrlCache.current.entries()).forEach(([id, value]) => {
+      if (!seen.has(id)) {
+        URL.revokeObjectURL(value.url);
+        previewObjectUrlCache.current.delete(id);
+      }
+    });
+
+    setPreviewUrls(nextUrls);
+  }, [entries]);
+
+  useEffect(() => {
+    return () => {
+      previewObjectUrlCache.current.forEach(({ url }) => URL.revokeObjectURL(url));
+      previewObjectUrlCache.current.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (openMenuId && !entries.some(entry => entry.id === openMenuId)) {
+      setOpenMenuId(null);
+    }
+  }, [entries, openMenuId]);
+
+  useEffect(() => {
+    if (!openMenuId) {
+      return;
+    }
+
+    const handleOutsideClick = () => setOpenMenuId(null);
+    document.addEventListener('click', handleOutsideClick);
+    return () => document.removeEventListener('click', handleOutsideClick);
+  }, [openMenuId]);
+
   const formatter = useMemo(() => {
     return new Intl.DateTimeFormat('ko-KR', {
       dateStyle: 'medium',
@@ -54,6 +208,11 @@ const RecipeJournal: React.FC<RecipeJournalProps> = ({
   const handleSaveNote = (id: string) => {
     const note = draftNotes[id] ?? '';
     onUpdate(id, { note });
+  };
+
+  const handleMenuToggle = (event: React.MouseEvent<HTMLButtonElement>, id: string) => {
+    event.stopPropagation();
+    setOpenMenuId(current => (current === id ? null : id));
   };
 
   return (
@@ -85,95 +244,165 @@ const RecipeJournal: React.FC<RecipeJournalProps> = ({
           {entries.map(entry => {
             const isHighlighted = entry.id === highlightedId;
             const draftNote = draftNotes[entry.id] ?? entry.note;
+            const previewUrl = previewUrls[entry.id] ?? entry.journalPreviewImage ?? null;
+            const placeholderVisual = buildPlaceholderStyle(`${entry.id}-${entry.recipeName}`);
+            const initials = getInitials(entry.recipeName);
+            const altText = t('journalPreviewAlt', { name: entry.recipeName });
+            const isAwaitingPreview = pendingPreviewIds.has(entry.id);
             return (
               <article
                 key={entry.id}
-                className={`border rounded-2xl p-5 space-y-4 transition-shadow bg-white ${
+                className={`border rounded-2xl p-4 sm:p-5 transition-shadow bg-white ${
                   isHighlighted ? 'border-brand-orange shadow-lg ring-2 ring-brand-orange/40' : 'border-gray-200 shadow-sm'
                 }`}
               >
-                <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
-                  <div>
-                    <h3 className="text-xl font-semibold text-gray-800">{entry.recipeName}</h3>
-                    <p className="text-xs text-gray-500">
-                      {t('journalCreatedAt', { date: formatter.format(new Date(entry.createdAt)) })}
-                    </p>
-                    {entry.timesCooked > 0 && (
-                      <p className="text-xs text-emerald-600 font-semibold mt-1">
-                        {t('journalTimesCooked', { count: entry.timesCooked })}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-widest">
-                    {entry.matchedIngredients && entry.matchedIngredients.length > 0 && (
-                      <span className="inline-flex items-center rounded-full bg-emerald-50 text-emerald-700 px-3 py-1">
-                        {t('journalMatchedBadge', { count: entry.matchedIngredients.length })}
-                      </span>
-                    )}
-                    {entry.missingIngredients && entry.missingIngredients.length > 0 && (
-                      <span className="inline-flex items-center rounded-full bg-amber-50 text-amber-700 px-3 py-1">
-                        {t('journalMissingBadge', { count: entry.missingIngredients.length })}
-                      </span>
-                    )}
-                  </div>
-                </header>
-
-                {entry.description && (
-                  <p className="text-sm text-gray-600 leading-relaxed bg-gray-50 border border-gray-200 rounded-2xl p-4">
-                    {entry.description}
-                  </p>
-                )}
-
-                <div className="space-y-3">
-                  <label className="text-xs font-semibold text-gray-600 uppercase tracking-widest">
-                    {t('journalNoteLabel')}
-                  </label>
-                  <textarea
-                    value={draftNote}
-                    onChange={event => setDraftNotes(current => ({ ...current, [entry.id]: event.target.value }))}
-                    rows={4}
-                    placeholder={t('journalNotePlaceholder')}
-                    className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-                  />
-                  <div className="flex flex-wrap justify-between gap-3">
-                    <button
-                      type="button"
-                      onClick={() => handleSaveNote(entry.id)}
-                      className="inline-flex items-center gap-2 rounded-xl bg-brand-blue text-white px-4 py-2 text-sm font-semibold shadow hover:bg-blue-600 transition"
+                <div className="flex flex-col gap-4 sm:flex-row">
+                  <div className="sm:w-40 md:w-48 flex-shrink-0">
+                    <div
+                      className="relative aspect-[4/3] overflow-hidden rounded-2xl border border-gray-200 bg-gray-100 shadow-inner"
+                      style={previewUrl ? undefined : placeholderVisual.style}
                     >
-                      {t('journalSaveNote')}
-                    </button>
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        onClick={() => onOpenDetails(entry.id)}
-                        className="inline-flex items-center gap-2 rounded-xl bg-brand-orange text-white px-4 py-2 text-sm font-semibold shadow hover:bg-orange-500 transition"
-                      >
-                        <FlameIcon />
-                        {t('journalOpenDetails')}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onMarkCooked(entry.id)}
-                        className="inline-flex items-center gap-2 rounded-xl border border-brand-orange/30 text-brand-orange px-4 py-2 text-sm font-semibold hover:bg-brand-orange/10 transition"
-                      >
-                        {entry.lastCookedAt ? t('journalQuickLogAgain') : t('journalQuickLogFirst')}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onDelete(entry.id)}
-                        className="inline-flex items-center gap-2 rounded-xl border border-red-200 text-red-500 px-4 py-2 text-sm font-semibold hover:bg-red-50 transition"
-                      >
-                        <TrashIcon />
-                        {t('journalDelete')}
-                      </button>
+                      {previewUrl ? (
+                        <img
+                          src={previewUrl}
+                          alt={altText}
+                          loading="lazy"
+                          className="h-full w-full object-cover transition-transform duration-300 hover:scale-[1.02]"
+                        />
+                      ) : (
+                        <div className="absolute inset-0 flex flex-col items-center justify-center text-white">
+                          <span
+                            className="text-2xl font-bold tracking-[0.4em] drop-shadow-[0_6px_12px_rgba(15,23,42,0.28)]"
+                            style={{ color: placeholderVisual.accent }}
+                          >
+                            {initials}
+                          </span>
+                          <span className="mt-2 text-[10px] font-semibold uppercase tracking-[0.45em] opacity-80">
+                            {t('journalPreviewPlaceholder')}
+                          </span>
+                        </div>
+                      )}
+                      {isAwaitingPreview && (
+                        <span className="absolute bottom-2 left-2 rounded-full bg-black/40 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.4em] text-white backdrop-blur">
+                          {t('journalPreviewGenerating')}
+                        </span>
+                      )}
+                      <div className="absolute top-2 right-2 z-10">
+                        <button
+                          type="button"
+                          onClick={event => handleMenuToggle(event, entry.id)}
+                          aria-label={t('journalPreviewMenuLabel')}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-gray-500 shadow-sm backdrop-blur transition hover:bg-white"
+                        >
+                          <MoreVerticalIcon />
+                        </button>
+                        {openMenuId === entry.id && (
+                          <div
+                            className="absolute right-0 mt-2 w-48 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl"
+                            onClick={event => event.stopPropagation()}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setOpenMenuId(null);
+                                onRegeneratePreview(entry.id);
+                              }}
+                              className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                            >
+                              {t('journalPreviewRegenerate')}
+                            </button>
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </div>
-                  {entry.lastCookedAt && (
-                    <p className="text-[11px] uppercase tracking-widest font-semibold text-gray-400">
-                      {t('journalLastCooked', { date: formatter.format(new Date(entry.lastCookedAt)) })}
-                    </p>
-                  )}
+                  <div className="flex-1 space-y-4">
+                    <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="space-y-1">
+                        <h3 className="text-xl font-semibold text-gray-800">{entry.recipeName}</h3>
+                        <p className="text-xs text-gray-500">
+                          {t('journalCreatedAt', { date: formatter.format(new Date(entry.createdAt)) })}
+                        </p>
+                        {entry.timesCooked > 0 && (
+                          <p className="text-xs text-emerald-600 font-semibold">
+                            {t('journalTimesCooked', { count: entry.timesCooked })}
+                          </p>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-widest">
+                        {entry.matchedIngredients && entry.matchedIngredients.length > 0 && (
+                          <span className="inline-flex items-center rounded-full bg-emerald-50 text-emerald-700 px-3 py-1">
+                            {t('journalMatchedBadge', { count: entry.matchedIngredients.length })}
+                          </span>
+                        )}
+                        {entry.missingIngredients && entry.missingIngredients.length > 0 && (
+                          <span className="inline-flex items-center rounded-full bg-amber-50 text-amber-700 px-3 py-1">
+                            {t('journalMissingBadge', { count: entry.missingIngredients.length })}
+                          </span>
+                        )}
+                      </div>
+                    </header>
+
+                    {entry.description && (
+                      <p className="text-sm text-gray-600 leading-relaxed bg-gray-50 border border-gray-200 rounded-2xl p-4">
+                        {entry.description}
+                      </p>
+                    )}
+
+                    <div className="space-y-3">
+                      <label className="text-xs font-semibold text-gray-600 uppercase tracking-widest">
+                        {t('journalNoteLabel')}
+                      </label>
+                      <textarea
+                        value={draftNote}
+                        onChange={event =>
+                          setDraftNotes(current => ({ ...current, [entry.id]: event.target.value }))
+                        }
+                        rows={4}
+                        placeholder={t('journalNotePlaceholder')}
+                        className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+                      />
+                      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <button
+                          type="button"
+                          onClick={() => handleSaveNote(entry.id)}
+                          className="inline-flex items-center justify-center gap-2 rounded-xl bg-brand-blue text-white px-4 py-2 text-sm font-semibold shadow hover:bg-blue-600 transition"
+                        >
+                          {t('journalSaveNote')}
+                        </button>
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            onClick={() => onOpenDetails(entry.id)}
+                            className="inline-flex items-center gap-2 rounded-xl bg-brand-orange text-white px-4 py-2 text-sm font-semibold shadow hover:bg-orange-500 transition"
+                          >
+                            <FlameIcon />
+                            {t('journalOpenDetails')}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onMarkCooked(entry.id)}
+                            className="inline-flex items-center gap-2 rounded-xl border border-brand-orange/30 text-brand-orange px-4 py-2 text-sm font-semibold hover:bg-brand-orange/10 transition"
+                          >
+                            {entry.lastCookedAt ? t('journalQuickLogAgain') : t('journalQuickLogFirst')}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onDelete(entry.id)}
+                            className="inline-flex items-center gap-2 rounded-xl border border-red-200 text-red-500 px-4 py-2 text-sm font-semibold hover:bg-red-50 transition"
+                          >
+                            <TrashIcon />
+                            {t('journalDelete')}
+                          </button>
+                        </div>
+                      </div>
+                      {entry.lastCookedAt && (
+                        <p className="text-[11px] uppercase tracking-widest font-semibold text-gray-400">
+                          {t('journalLastCooked', { date: formatter.format(new Date(entry.lastCookedAt)) })}
+                        </p>
+                      )}
+                    </div>
+                  </div>
                 </div>
               </article>
             );

--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -188,6 +188,11 @@ export const journalQuickLogAgain = '오늘도 요리했어요';
 export const journalQuickLogFirst = '오늘 첫 요리 기록';
 export const journalDelete = '기록에서 삭제';
 export const journalLastCooked = '마지막 요리: {{date}}';
+export const journalPreviewMenuLabel = '썸네일 옵션 열기';
+export const journalPreviewRegenerate = '썸네일 다시 생성';
+export const journalPreviewPlaceholder = '썸네일 준비 중';
+export const journalPreviewGenerating = '생성 중…';
+export const journalPreviewAlt = '{{name}} 레시피 저널 썸네일';
 
 export const recipeModalJournalTitle = '이 레시피를 기록장에 저장하기';
 export const recipeModalJournalSubtitle = '다음에 참고할 변형, 양 조절, 만든 횟수를 한곳에 모아두세요.';

--- a/camera-food-reciepe-main/services/designPreviewService.ts
+++ b/camera-food-reciepe-main/services/designPreviewService.ts
@@ -1,0 +1,170 @@
+interface DesignPreviewRequest {
+  recipeName: string;
+  matchedIngredients?: string[];
+  missingIngredients?: string[];
+  artStyle?: string;
+}
+
+export interface DesignPreviewResponse {
+  dataUrl: string;
+  prompt: string;
+}
+
+const DEFAULT_ART_STYLE = 'warm tabletop scene with soft watercolor lighting';
+
+const palette = [
+  ['#FEF3C7', '#FDBA74', '#F97316'],
+  ['#DBEAFE', '#A5B4FC', '#6366F1'],
+  ['#DCFCE7', '#86EFAC', '#16A34A'],
+  ['#FCE7F3', '#F9A8D4', '#EC4899'],
+  ['#FFE4E6', '#FCA5A5', '#EF4444'],
+  ['#E0F2FE', '#7DD3FC', '#0EA5E9'],
+];
+
+const secondaryPalette = ['#0F172A', '#111827', '#1F2937', '#312E81', '#4C1D95', '#1E3A8A'];
+
+const toBase64 = (value: string) => {
+  if (typeof btoa === 'function') {
+    return btoa(
+      encodeURIComponent(value).replace(/%([0-9A-F]{2})/g, (_, code: string) =>
+        String.fromCharCode(parseInt(code, 16))
+      )
+    );
+  }
+  return Buffer.from(value, 'utf-8').toString('base64');
+};
+
+const escapeForSvg = (value: string) =>
+  value.replace(/[&<>'"]/g, character => {
+    switch (character) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case "'":
+        return '&apos;';
+      case '"':
+        return '&quot;';
+      default:
+        return character;
+    }
+  });
+
+const hashString = (value: string) => {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+};
+
+const buildPrompt = ({
+  recipeName,
+  matchedIngredients = [],
+  missingIngredients = [],
+  artStyle = DEFAULT_ART_STYLE,
+}: DesignPreviewRequest) => {
+  const matched = matchedIngredients.filter(Boolean).join(', ');
+  const missing = missingIngredients.filter(Boolean).join(', ');
+  const parts = [`Create an illustrated journal card for the recipe “${recipeName}”.`];
+
+  if (matched) {
+    parts.push(`Highlight on-hand ingredients: ${matched}.`);
+  }
+
+  if (missing) {
+    parts.push(`Suggest what's missing: ${missing}.`);
+  }
+
+  parts.push(`Overall art direction: ${artStyle}.`);
+  return parts.join(' ');
+};
+
+const buildSvg = (
+  request: DesignPreviewRequest,
+  prompt: string,
+  colors: string[],
+  accent: string
+) => {
+  const { recipeName } = request;
+  const matched = request.matchedIngredients?.filter(Boolean) ?? [];
+  const missing = request.missingIngredients?.filter(Boolean) ?? [];
+  const artStyle = request.artStyle ?? DEFAULT_ART_STYLE;
+
+  const bannerText = escapeForSvg(recipeName);
+  const matchedText = escapeForSvg(matched.slice(0, 5).join(' · ') || 'On-hand ingredients recorded');
+  const missingText = escapeForSvg(
+    missing.length > 0 ? `Pick up: ${missing.slice(0, 5).join(', ')}` : 'Everything you need is here'
+  );
+  const artStyleText = escapeForSvg(artStyle);
+  const promptText = escapeForSvg(prompt);
+
+  const overlayOpacity = 0.14 + (colors[2].length % 4) * 0.06;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 300" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="${colors[0]}" />
+      <stop offset="50%" stop-color="${colors[1]}" />
+      <stop offset="100%" stop-color="${colors[2]}" />
+    </linearGradient>
+    <pattern id="grain" width="8" height="8" patternUnits="userSpaceOnUse">
+      <circle cx="1" cy="1" r="1" fill="${accent}" opacity="0.08" />
+      <circle cx="4" cy="3" r="1" fill="${accent}" opacity="0.1" />
+      <circle cx="7" cy="2" r="1" fill="${accent}" opacity="0.06" />
+      <circle cx="3" cy="6" r="1" fill="${accent}" opacity="0.08" />
+    </pattern>
+    <clipPath id="card-clip">
+      <rect x="16" y="16" width="388" height="268" rx="28" ry="28" />
+    </clipPath>
+  </defs>
+  <g clip-path="url(#card-clip)">
+    <rect x="16" y="16" width="388" height="268" fill="url(#bg)" />
+    <rect x="16" y="16" width="388" height="268" fill="url(#grain)" />
+    <path d="M16 150 C140 120 220 210 404 130 L404 284 L16 284 Z" fill="${accent}" opacity="${overlayOpacity.toFixed(2)}" />
+  </g>
+  <rect x="16" y="16" width="388" height="268" rx="28" ry="28" fill="none" stroke="${accent}" stroke-width="1.5" opacity="0.6" />
+  <text x="32" y="72" font-family="'Pretendard', 'Inter', sans-serif" font-weight="700" font-size="26" fill="${secondaryPalette[hashString(recipeName) % secondaryPalette.length]}" letter-spacing="0.8">
+    ${bannerText}
+  </text>
+  <text x="32" y="108" font-family="'Pretendard', 'Inter', sans-serif" font-size="13" fill="#1F2937" opacity="0.78">
+    ${artStyleText}
+  </text>
+  <text x="32" y="144" font-family="'Pretendard', 'Inter', sans-serif" font-size="12" fill="#1F2937" opacity="0.86">
+    ${matchedText}
+  </text>
+  <text x="32" y="170" font-family="'Pretendard', 'Inter', sans-serif" font-size="12" fill="#1F2937" opacity="0.7">
+    ${missingText}
+  </text>
+  <text x="32" y="210" font-family="'Pretendard', 'Inter', sans-serif" font-size="10" fill="#111827" opacity="0.5" letter-spacing="0.4">
+    ${promptText}
+  </text>
+  <text x="32" y="244" font-family="'Pretendard', 'Inter', sans-serif" font-size="10" fill="#111827" opacity="0.38">
+    auto-generated thumbnail preview
+  </text>
+</svg>`;
+};
+
+export const designPreviewService = async (
+  request: DesignPreviewRequest
+): Promise<DesignPreviewResponse> => {
+  const prompt = buildPrompt(request);
+  const paletteIndex = hashString(prompt) % palette.length;
+  const accentIndex = hashString(`${prompt}:${request.recipeName}`) % secondaryPalette.length;
+  const colors = palette[paletteIndex];
+  const accent = secondaryPalette[accentIndex];
+  const svg = buildSvg(request, prompt, colors, accent);
+  const encoded = toBase64(svg);
+  const dataUrl = `data:image/svg+xml;base64,${encoded}`;
+
+  // small async pause to emulate network fetch and allow UI affordances
+  await new Promise(resolve => {
+    setTimeout(resolve, 120);
+  });
+
+  return { dataUrl, prompt };
+};

--- a/camera-food-reciepe-main/types.ts
+++ b/camera-food-reciepe-main/types.ts
@@ -86,6 +86,7 @@ export interface RecipeMemory {
     note: string;
     matchedIngredients?: string[];
     missingIngredients?: string[];
+    journalPreviewImage?: string | null;
     lastCookedAt?: string | null;
     timesCooked: number;
     ingredients?: string[];


### PR DESCRIPTION
## Summary
- add a client-side design preview service and persist preview data on recipe memories, including migration defaults
- trigger preview generation when saving or regenerating memories and track pending state for cleanup
- redesign the recipe journal list with thumbnail frames, placeholders, and overflow actions for refreshing previews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dac0cc252c8328b741137837451c5d