### PR TITLE
Add AI-generated recipe preview images

### DIFF
--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -90,6 +90,10 @@ export const recipeModalViewRecipe = '자세한 레시피 보기 →';
 export const recipeModalDetectedIngredientsTitle = '스캔된 재료 확인';
 export const recipeModalDetectedIngredientsDescription =
   '최근 스캔에서 인식한 재료예요. 필요한 재료가 빠지지 않았는지 가볍게 확인해보세요.';
+export const recipeModalPreviewLoading = '플레이팅 미리보기를 준비하고 있어요...';
+export const recipeModalPreviewError = '미리보기를 불러오지 못했어요.';
+export const recipeModalPreviewRetry = '다시 시도';
+export const recipeModalPreviewRefresh = '미리보기 새로고침';
 export const recipeModalNutritionSnapshotTitle = '현재 영양 요약';
 export const recipeModalNutritionSnapshotSubtitle = '감지된 재료 {{count}}개 기준';
 export const recipeModalNutritionSnapshotHint = '참고용 수치예요. 레시피별로 “영양 보기”를 눌러 더 정확한 추정을 확인하세요.';

--- a/camera-food-reciepe-main/services/designPreviewService.ts
+++ b/camera-food-reciepe-main/services/designPreviewService.ts
@@ -1,4 +1,5 @@
 import { GoogleGenAI, Type } from '@google/genai';
+import type { RecipeRecommendation } from '../types';
 
 const GEMINI_API_KEY =
   (process.env.GEMINI_API_KEY as string | undefined) ?? (process.env.API_KEY as string | undefined);
@@ -26,25 +27,57 @@ const normalizeIngredients = (ingredients: string[]): string[] =>
     .map(ingredient => ingredient.trim())
     .filter((ingredient, index, self) => ingredient && self.findIndex(value => value.toLowerCase() === ingredient.toLowerCase()) === index);
 
-export async function generateDesignPreview(ingredients: string[]): Promise<string> {
+const recipePreviewCachePrefix = 'recipe-preview:';
+
+const readFromLocalStorage = (key: string): string | null => {
+  if (typeof window === 'undefined' || !window?.localStorage) {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    console.warn('Unable to read recipe preview cache', error);
+    return null;
+  }
+};
+
+const writeToLocalStorage = (key: string, value: string) => {
+  if (typeof window === 'undefined' || !window?.localStorage) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    console.warn('Unable to persist recipe preview cache', error);
+  }
+};
+
+const removeFromLocalStorage = (key: string) => {
+  if (typeof window === 'undefined' || !window?.localStorage) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    console.warn('Unable to clear recipe preview cache', error);
+  }
+};
+
+const deriveRecipePreviewKey = (recipe: RecipeRecommendation): string => {
+  const candidateId = (recipe as { id?: string | number | null }).id;
+  const resolvedId = candidateId != null && String(candidateId).trim().length > 0
+    ? String(candidateId).trim()
+    : recipe.recipeName.trim();
+  return `${recipePreviewCachePrefix}${resolvedId.toLowerCase()}`;
+};
+
+const requestPreviewFromGemini = async (prompt: string): Promise<string> => {
   if (!GEMINI_API_KEY || !ai) {
     throw new Error('error_gemini_api_key');
   }
-
-  const sanitizedIngredients = normalizeIngredients(ingredients);
-
-  if (sanitizedIngredients.length === 0) {
-    throw new Error('error_design_preview_fetch');
-  }
-
-  const prompt = [
-    'You are a culinary art director helping a cooking assistant app feel inspiring when users scan their fridge.',
-    'Create a single evocative moodboard preview image that blends the detected ingredients into a cohesive cooking inspiration scene.',
-    'Use soft natural lighting, minimal text, and avoid including people. The focus should be on textures, colors, and plating ideas.',
-    'Return the final image as base64 encoded data (PNG or JPEG). Do not include any additional commentary.',
-    '',
-    `Detected ingredients: ${sanitizedIngredients.join(', ')}`,
-  ].join('\n');
 
   try {
     const response = await ai.models.generateContent({
@@ -104,4 +137,55 @@ export async function generateDesignPreview(ingredients: string[]): Promise<stri
     console.error('Error generating design preview from Gemini API:', error);
     throw new Error('error_design_preview_fetch');
   }
+};
+
+export async function generateDesignPreview(ingredients: string[]): Promise<string> {
+  const sanitizedIngredients = normalizeIngredients(ingredients);
+
+  if (sanitizedIngredients.length === 0) {
+    throw new Error('error_design_preview_fetch');
+  }
+
+  const prompt = [
+    'You are a culinary art director helping a cooking assistant app feel inspiring when users scan their fridge.',
+    'Create a single evocative moodboard preview image that blends the detected ingredients into a cohesive cooking inspiration scene.',
+    'Use soft natural lighting, minimal text, and avoid including people. The focus should be on textures, colors, and plating ideas.',
+    'Return the final image as base64 encoded data (PNG or JPEG). Do not include any additional commentary.',
+    '',
+    `Detected ingredients: ${sanitizedIngredients.join(', ')}`,
+  ].join('\n');
+
+  return requestPreviewFromGemini(prompt);
+}
+
+export const getRecipePreviewCacheKey = (recipe: RecipeRecommendation): string => deriveRecipePreviewKey(recipe);
+
+export const clearRecipePreviewCache = (recipe: RecipeRecommendation) => {
+  const key = deriveRecipePreviewKey(recipe);
+  removeFromLocalStorage(key);
+};
+
+export async function fetchRecipePreviewImage(recipe: RecipeRecommendation): Promise<string> {
+  const cacheKey = deriveRecipePreviewKey(recipe);
+  const cached = readFromLocalStorage(cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const prompt = [
+    'You are an imaginative food photographer crafting a stylized hero shot for a recipe recommendation card.',
+    `Recipe name: ${recipe.recipeName.trim()}`,
+    recipe.description ? `Recipe description: ${recipe.description.trim()}` : null,
+    'Create a single appetizing photograph of the finished dish plated beautifully on a modern table.',
+    'Use soft daylight, emphasize vibrant colors, and avoid any text overlays, logos, hands, or people.',
+    'Return only base64 encoded PNG or JPEG data for the generated image.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const imageData = await requestPreviewFromGemini(prompt);
+  writeToLocalStorage(cacheKey, imageData);
+
+  return imageData;
 }

--- a/camera-food-reciepe-main/types.ts
+++ b/camera-food-reciepe-main/types.ts
@@ -45,6 +45,8 @@ export interface RecipeRecommendation extends RecipeWithVideos {
     missingIngredients: string[];
     matchedIngredients: string[];
     isFullyMatched: boolean;
+    previewImage?: string;
+    previewStatus?: 'idle' | 'loading' | 'error';
 }
 
 export interface NutrientProfile {


### PR DESCRIPTION
## Summary
- extend recipe recommendation metadata to include preview image fields
- add a Gemini-backed recipe preview fetcher with localStorage caching helpers
- surface generated previews in the recipe modal with loading, error, and refresh states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dac43003848328b6ff6c8f5c6eae00