### PR TITLE
Use Gemini image generation API for preview images

### DIFF
--- a/camera-food-reciepe-main/services/designPreviewService.ts
+++ b/camera-food-reciepe-main/services/designPreviewService.ts
@@ -1,26 +1,10 @@
-import { GoogleGenAI, Type } from '@google/genai';
+import { GoogleGenAI } from '@google/genai';
 import type { RecipeRecommendation } from '../types';
 
 const GEMINI_API_KEY =
   (process.env.GEMINI_API_KEY as string | undefined) ?? (process.env.API_KEY as string | undefined);
 
 const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
-
-const previewSchema = {
-  type: Type.OBJECT,
-  properties: {
-    imageData: {
-      type: Type.STRING,
-      description:
-        'Base64 encoded PNG or JPEG image data that visually represents a culinary moodboard inspired by the provided ingredients.',
-    },
-    mimeType: {
-      type: Type.STRING,
-      description: 'Optional MIME type for the encoded image (image/png or image/jpeg).',
-    },
-  },
-  required: ['imageData'],
-};
 
 const normalizeIngredients = (ingredients: string[]): string[] =>
   ingredients
@@ -89,59 +73,26 @@ const requestPreviewFromGemini = async (prompt: string): Promise<string> => {
   }
 
   try {
-    const response = await ai.models.generateContent({
+    const response = await ai.models.generateImages({
       model: 'gemini-2.5-flash-image-preview',
-      contents: [
-        {
-          role: 'user',
-          parts: [{ text: prompt }],
-        },
-      ],
+      prompt,
       config: {
-        responseMimeType: 'application/json',
-        responseSchema: previewSchema,
-        temperature: 0.4,
+        numberOfImages: 1,
       },
     });
 
-    const candidateParts = (response as any)?.candidates?.flatMap((candidate: any) => candidate?.content?.parts ?? []) ?? [];
-    const inlinePart = candidateParts.find((part: any) => part?.inlineData?.data);
+    const generatedImage = response.generatedImages?.[0]?.image;
+    const imageBytes = generatedImage?.imageBytes?.trim();
 
-    if (inlinePart?.inlineData?.data) {
-      const mimeType = typeof inlinePart.inlineData.mimeType === 'string' && inlinePart.inlineData.mimeType.trim()
-        ? inlinePart.inlineData.mimeType.trim()
-        : 'image/png';
-      const data = String(inlinePart.inlineData.data).trim();
-      if (!data) {
-        throw new Error('error_design_preview_fetch');
-      }
-      return `data:${mimeType};base64,${data}`;
-    }
-
-    let jsonText: string | undefined = response.text;
-    if (!jsonText) {
-      const fallback = (response as { output_text?: string | undefined }).output_text;
-      if (typeof fallback === 'string') {
-        jsonText = fallback;
-      }
-    }
-
-    const trimmedJson = jsonText?.trim();
-    if (!trimmedJson) {
+    if (!imageBytes) {
       throw new Error('error_design_preview_fetch');
     }
 
-    const parsed = JSON.parse(trimmedJson) as { imageData?: string; image?: string; mimeType?: string };
-    const base64 = (parsed.imageData ?? parsed.image ?? '').trim();
+    const mimeType = generatedImage?.mimeType && generatedImage.mimeType.trim()
+      ? generatedImage.mimeType.trim()
+      : 'image/png';
 
-    if (!base64) {
-      throw new Error('error_design_preview_fetch');
-    }
-
-    const mimeType = (parsed.mimeType ?? 'image/png').trim();
-    const normalizedMimeType = mimeType.startsWith('image/') ? mimeType : `image/${mimeType}`;
-
-    return `data:${normalizedMimeType};base64,${base64}`;
+    return `data:${mimeType};base64,${imageBytes}`;
   } catch (error) {
     console.error('Error generating design preview from Gemini API:', error);
     throw new Error('error_design_preview_fetch');


### PR DESCRIPTION
## Summary
- switch the design preview service to call `generateImages` for Gemini previews
- extract the first image response into a base64 data URL while keeping localStorage caching intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db7563e0fc83288acc44baae09d291