### PR TITLE
Add shared ingredient parsing helper

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -23,6 +23,7 @@ import { getRecipeSuggestions } from './services/geminiService';
 import { generateDesignPreview, generateJournalPreviewImage } from './services/designPreviewService';
 import { analyzeIngredientsFromImage } from './services/visionService';
 import { getRecipeVideos } from './services/videoService';
+import { parseIngredientInput, sanitizeIngredients } from './services/ingredientParser';
 import { SparklesIcon, CameraIcon, BookOpenIcon, PulseIcon } from './components/icons';
 import { useLanguage } from './context/LanguageContext';
 import { estimateNutritionSummary } from './services/nutritionService';
@@ -166,31 +167,12 @@ const App: React.FC = () => {
 
   const normalizeIngredientName = (ingredient: string) => ingredient.trim().toLowerCase();
 
-  const sanitizeIngredients = (rawIngredients: string[]) => {
-    const seen = new Set<string>();
-    const sanitized: string[] = [];
-
-    rawIngredients.forEach(ingredient => {
-      const trimmed = ingredient.trim();
-      if (!trimmed) return;
-      const key = trimmed.toLowerCase();
-      if (seen.has(key)) return;
-      seen.add(key);
-      sanitized.push(trimmed);
-    });
-
-    return sanitized;
-  };
-
   const manualInputPreviewCount = useMemo(() => {
     if (!manualIngredientsInput.trim()) {
       return 0;
     }
 
-    const rawEntries = manualIngredientsInput
-      .split(/[\n,]/)
-      .map(entry => entry.trim())
-      .filter(Boolean);
+    const rawEntries = parseIngredientInput(manualIngredientsInput);
 
     return sanitizeIngredients(rawEntries).length;
   }, [manualIngredientsInput]);
@@ -635,10 +617,7 @@ const App: React.FC = () => {
 
   const handleManualIngredientsSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const rawEntries = manualIngredientsInput
-      .split(/[\n,]/)
-      .map(entry => entry.trim())
-      .filter(Boolean);
+    const rawEntries = parseIngredientInput(manualIngredientsInput);
     const sanitized = sanitizeIngredients(rawEntries);
 
     if (sanitized.length === 0) {

--- a/camera-food-reciepe-main/components/RecipeModal.tsx
+++ b/camera-food-reciepe-main/components/RecipeModal.tsx
@@ -12,6 +12,7 @@ import {
   fetchRecipePreviewImage,
   getRecipePreviewCacheKey,
 } from '../services/designPreviewService';
+import { parseIngredientInput } from '../services/ingredientParser';
 
 const extractStepSummary = (instruction: string) => {
   const cleaned = instruction.trim();
@@ -306,10 +307,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
   };
 
   const handleApplyIngredientEdits = async () => {
-    const parsed = ingredientsEditorValue
-      .split(/[\n,]/)
-      .map(entry => entry.trim())
-      .filter(Boolean);
+    const parsed = parseIngredientInput(ingredientsEditorValue);
 
     if (parsed.length === 0) {
       setIngredientsEditorError(t('recipeModalEditIngredientsError'));

--- a/camera-food-reciepe-main/services/ingredientParser.test.ts
+++ b/camera-food-reciepe-main/services/ingredientParser.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { parseIngredientInput, sanitizeIngredients } from './ingredientParser';
+
+describe('parseIngredientInput', () => {
+  it('splits text by punctuation and newlines', () => {
+    const input = 'onion, garlic\npepper; basil · thyme';
+    expect(parseIngredientInput(input)).toEqual(['onion', 'garlic', 'pepper', 'basil', 'thyme']);
+  });
+
+  it('falls back to whitespace splitting when delimiters are absent', () => {
+    const input = 'apple banana   carrot';
+    expect(parseIngredientInput(input)).toEqual(['apple', 'banana', 'carrot']);
+  });
+
+  it('integrates with sanitizeIngredients to deduplicate and trim entries', () => {
+    const spaceSeparated = 'eggplant   tomato  tomato';
+    const mixedSeparated = 'milk, cream\nbutter; yogurt · cream';
+
+    expect(sanitizeIngredients(parseIngredientInput(spaceSeparated)).length).toBe(2);
+    expect(sanitizeIngredients(parseIngredientInput(mixedSeparated)).length).toBe(4);
+  });
+});

--- a/camera-food-reciepe-main/services/ingredientParser.ts
+++ b/camera-food-reciepe-main/services/ingredientParser.ts
@@ -1,0 +1,35 @@
+export const parseIngredientInput = (text: string): string[] => {
+  if (!text) {
+    return [];
+  }
+
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  const primarySeparators = /[\n,;·]/;
+  const hasPrimarySeparator = primarySeparators.test(trimmed);
+  const splitter = hasPrimarySeparator ? /[\n,;·]+/ : /\s+/;
+
+  return trimmed
+    .split(splitter)
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0);
+};
+
+export const sanitizeIngredients = (rawIngredients: string[]): string[] => {
+  const seen = new Set<string>();
+  const sanitized: string[] = [];
+
+  rawIngredients.forEach(ingredient => {
+    const trimmed = ingredient.trim();
+    if (!trimmed) return;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    sanitized.push(trimmed);
+  });
+
+  return sanitized;
+};


### PR DESCRIPTION
## Summary
- add a shared ingredient parser with punctuation and whitespace fallbacks
- update manual and modal ingredient flows to reuse the new helper and sanitizer
- add tests covering parser behaviour and sanitization counts

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68db799d8c348328ba8ceb6d55b31b1b