### PR TITLE
Handle missing Gemini key before requesting previews

### DIFF
--- a/camera-food-reciepe-main/components/RecipeModal.tsx
+++ b/camera-food-reciepe-main/components/RecipeModal.tsx
@@ -11,6 +11,7 @@ import {
   clearRecipePreviewCache,
   fetchRecipePreviewImage,
   getRecipePreviewCacheKey,
+  isDesignPreviewSupported,
 } from '../services/designPreviewService';
 import { parseIngredientInput } from '../services/ingredientParser';
 
@@ -55,7 +56,7 @@ const extractStepSummary = (instruction: string) => {
 };
 
 type PreviewState = {
-  status: 'idle' | 'loading' | 'success' | 'error';
+  status: 'idle' | 'loading' | 'success' | 'error' | 'unsupported';
   image?: string;
 };
 
@@ -209,6 +210,17 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
         return;
       }
 
+      if (!isDesignPreviewSupported) {
+        setPreviews(prev => ({
+          ...prev,
+          [key]: {
+            status: 'unsupported',
+            image: undefined,
+          },
+        }));
+        return;
+      }
+
       if (!skipStatePriming) {
         setPreviews(prev => ({
           ...prev,
@@ -262,6 +274,18 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
   const handleRefreshPreview = useCallback(
     (recipe: RecipeRecommendation) => {
       const key = previewKeyForRecipe(recipe);
+
+      if (!isDesignPreviewSupported) {
+        setPreviews(prev => ({
+          ...prev,
+          [key]: {
+            status: 'unsupported',
+            image: undefined,
+          },
+        }));
+        return;
+      }
+
       clearRecipePreviewCache(recipe);
 
       setPreviews(prev => ({
@@ -500,6 +524,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                 const previewState = previews[previewKey] ?? { status: 'idle', image: undefined };
                 const isPreviewLoading = previewState.status === 'loading';
                 const isPreviewError = previewState.status === 'error';
+                const isPreviewUnsupported = previewState.status === 'unsupported';
                 const previewImage = previewState.status === 'success' ? previewState.image : undefined;
                 const providerVideos = recipe.videos;
 
@@ -519,7 +544,12 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                             className="h-48 w-full object-cover"
                           />
                         )}
-                        {isPreviewError && !previewImage && !isPreviewLoading && (
+                        {isPreviewUnsupported && !previewImage && !isPreviewLoading && (
+                          <div className="flex h-48 w-full items-center justify-center bg-gray-50 px-6 text-center text-sm font-medium text-gray-500">
+                            {t('error_gemini_api_key')}
+                          </div>
+                        )}
+                        {isPreviewError && !previewImage && !isPreviewLoading && !isPreviewUnsupported && (
                           <div className="flex h-48 w-full flex-col items-center justify-center gap-2 bg-gray-50 text-center text-sm text-gray-500">
                             <p>{t('recipeModalPreviewError')}</p>
                             <button
@@ -531,7 +561,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                             </button>
                           </div>
                         )}
-                        {!previewImage && !isPreviewLoading && !isPreviewError && (
+                        {!previewImage && !isPreviewLoading && !isPreviewError && !isPreviewUnsupported && (
                           <div className="flex h-48 w-full items-center justify-center bg-gray-100 text-xs font-medium text-gray-500">
                             {t('recipeModalPreviewLoading')}
                           </div>
@@ -540,7 +570,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                           <button
                             type="button"
                             onClick={() => handleRefreshPreview(recipe)}
-                            disabled={isPreviewLoading}
+                            disabled={isPreviewLoading || isPreviewUnsupported}
                             className="inline-flex items-center gap-1.5 rounded-full bg-white/85 px-3 py-1 text-[11px] font-semibold text-gray-600 shadow-sm ring-1 ring-white transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
                             aria-label={t('recipeModalPreviewRefresh')}
                           >

--- a/camera-food-reciepe-main/services/designPreviewService.ts
+++ b/camera-food-reciepe-main/services/designPreviewService.ts
@@ -4,7 +4,9 @@ import type { RecipeRecommendation } from '../types';
 const GEMINI_API_KEY =
   (process.env.GEMINI_API_KEY as string | undefined) ?? (process.env.API_KEY as string | undefined);
 
-const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
+export const isDesignPreviewSupported = Boolean(GEMINI_API_KEY);
+
+const ai = isDesignPreviewSupported ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
 
 const normalizeIngredients = (ingredients: string[]): string[] =>
   ingredients
@@ -68,7 +70,7 @@ const deriveRecipePreviewKey = (recipe: RecipeRecommendation): string => {
 };
 
 const requestPreviewFromGemini = async (prompt: string): Promise<string> => {
-  if (!GEMINI_API_KEY || !ai) {
+  if (!isDesignPreviewSupported || !ai) {
     throw new Error('error_gemini_api_key');
   }
 
@@ -106,6 +108,10 @@ export async function generateDesignPreview(ingredients: string[]): Promise<stri
     throw new Error('error_design_preview_fetch');
   }
 
+  if (!isDesignPreviewSupported) {
+    throw new Error('error_gemini_api_key');
+  }
+
   const prompt = [
     'You are a culinary art director helping a cooking assistant app feel inspiring when users scan their fridge.',
     'Create a single evocative moodboard preview image that blends the detected ingredients into a cohesive cooking inspiration scene.',
@@ -126,6 +132,10 @@ export const clearRecipePreviewCache = (recipe: RecipeRecommendation) => {
 };
 
 export async function fetchRecipePreviewImage(recipe: RecipeRecommendation): Promise<string> {
+  if (!isDesignPreviewSupported) {
+    throw new Error('error_gemini_api_key');
+  }
+
   const cacheKey = deriveRecipePreviewKey(recipe);
   const cached = readFromLocalStorage(cacheKey);
 
@@ -156,6 +166,10 @@ export async function generateJournalPreviewImage(options: JournalPreviewOptions
   const normalizedName = recipeName.trim();
   if (!normalizedName) {
     throw new Error('error_design_preview_fetch');
+  }
+
+  if (!isDesignPreviewSupported) {
+    throw new Error('error_gemini_api_key');
   }
 
   const available = normalizeIngredients(matchedIngredients);


### PR DESCRIPTION
## Summary
- expose a design preview support flag so Gemini requests fail fast without a key
- guard recipe preview requests and show a localized placeholder when previews are unsupported

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db81c64f148328ba7cffc88c918575