### PR TITLE
Handle missing YouTube API key gracefully

### DIFF
--- a/camera-food-reciepe-main/components/RecipeModal.tsx
+++ b/camera-food-reciepe-main/components/RecipeModal.tsx
@@ -80,6 +80,7 @@ interface RecipeModalProps {
   nutritionContext?: NutritionContext | null;
   onViewRecipeNutrition: (recipe: RecipeRecommendation) => void;
   onApplyDetectedIngredients: (ingredients: string[]) => Promise<string[]>;
+  videoAvailabilityNotice?: string | null;
 }
 
 const LoadingSkeleton: React.FC = () => (
@@ -104,6 +105,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
   nutritionContext,
   onViewRecipeNutrition,
   onApplyDetectedIngredients,
+  videoAvailabilityNotice,
 }) => {
   const { t } = useLanguage();
   if (!isOpen) return null;
@@ -656,7 +658,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                               ))
                             ) : (
                               <div className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-xs text-gray-500 shadow-sm md:text-right">
-                                {t('recipeModalProviderNoVideos')}
+                                {videoAvailabilityNotice ?? t('recipeModalProviderNoVideos')}
                               </div>
                             )}
                           </div>
@@ -738,7 +740,9 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                             ))}
                           </div>
                         ) : (
-                          <p className="text-sm text-gray-400">{t('recipeModalNoVideos')}</p>
+                          <p className="text-sm text-gray-400">
+                            {videoAvailabilityNotice ?? t('recipeModalNoVideos')}
+                          </p>
                         )}
                       </div>
                     </div>

--- a/camera-food-reciepe-main/services/videoService.test.ts
+++ b/camera-food-reciepe-main/services/videoService.test.ts
@@ -134,4 +134,20 @@ describe('getRecipeVideos', () => {
     expect(videos).toHaveLength(1);
     expect(videos[0]?.id).toBe('positive');
   });
+
+  it('throws an explicit error when the API key is missing', async () => {
+    delete process.env.YOUTUBE_API_KEY;
+    delete process.env.API_KEY;
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+    const { getRecipeVideos } = await import('./videoService');
+
+    await expect(getRecipeVideos('Bibimbap', ['rice'])).rejects.toThrowError(
+      new Error('error_youtube_api_key')
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    process.env.YOUTUBE_API_KEY = 'test-api-key';
+  });
 });

--- a/camera-food-reciepe-main/services/videoService.ts
+++ b/camera-food-reciepe-main/services/videoService.ts
@@ -104,8 +104,7 @@ const scoreVideo = (title: string | undefined, recipeName: string, ingredients: 
 
 export async function getRecipeVideos(recipeName: string, ingredients: string[], maxResults = 4): Promise<RecipeVideo[]> {
   if (!YOUTUBE_API_KEY) {
-    console.warn('YOUTUBE_API_KEY (or API_KEY) environment variable is not set. No recipe videos will be returned.');
-    return [];
+    throw new Error('error_youtube_api_key');
   }
 
   try {


### PR DESCRIPTION
## Summary
- throw a dedicated `error_youtube_api_key` error when the YouTube API key is not configured
- surface the configuration notice in recipe fetching logic and recipe modal video sections
- cover the missing key behaviour with a dedicated unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db81c773408328a43fc10f32eebf99