### PR TITLE
Fix README formatting for GitHub rendering

### DIFF
--- a/camera-food-reciepe-main/README.md
+++ b/camera-food-reciepe-main/README.md
@@ -1,25 +1,21 @@
-diff --git a/camera-food-reciepe-main/README.md b/camera-food-reciepe-main/README.md
-index a4812bcc3d031391576f28ff39962d87816fa3b5..34646da0c8082de1c89b719a08de0b4d642d0793 100644
---- a/camera-food-reciepe-main/README.md
-+++ b/camera-food-reciepe-main/README.md
-@@ -1,20 +1,23 @@
- <div align="center">
- <img width="1200" height="475" alt="GHBanner" src="https://github.com/user-attachments/assets/0aa67016-6eaf-458a-adb2-6e31a0763ed6" />
- </div>
- 
- # Run and deploy your AI Studio app
- 
- This contains everything you need to run your app locally.
- 
- View your app in AI Studio: https://ai.studio/apps/drive/1iNDCanOspkZrC13tqzikF_uY2Ridlbou
- 
- ## Run Locally
- 
- **Prerequisites:**  Node.js
- 
- 
+<div align="center">
+  <img width="1200" height="475" alt="GHBanner" src="https://github.com/user-attachments/assets/0aa67016-6eaf-458a-adb2-6e31a0763ed6" />
+</div>
+
+# Run and deploy your AI Studio app
+
+This repository contains everything you need to run your app locally.
+
+View your app in AI Studio: https://ai.studio/apps/drive/1iNDCanOspkZrC13tqzikF_uY2Ridlbou
+
+## Run Locally
+
+**Prerequisites:** Node.js
+
 1. Install dependencies:
-   `npm install`
+   ```bash
+   npm install
+   ```
 2. Set the following environment variables in [.env.local](.env.local):
    - `GEMINI_API_KEY` for your Gemini access token. This key powers both text recipes and the built-in vision fallback.
    - `GEMINI_IMAGE_MODEL` (optional) to override the Gemini image model used for AI thumbnails. Defaults to `imagen-3.0-generate-002`; set to `gemini-2.5-flash-image-preview` if your project has access to the preview-only model.
@@ -29,7 +25,9 @@ index a4812bcc3d031391576f28ff39962d87816fa3b5..34646da0c8082de1c89b719a08de0b4d
    - `VITE_SPOONACULAR_API_KEY` (optional) for direct recipe matches from the Spoonacular API. Without this key the app will fall back to other providers.
    - If you do not provide a `VISION_API_URL`, the app will automatically analyze photos with Gemini 1.5 Flash using the `GEMINI_API_KEY`.
 3. Run the app:
-   `npm run dev`
+   ```bash
+   npm run dev
+   ```
 
 ### Recipe link providers
 


### PR DESCRIPTION
## Summary
- replace the diff-formatted README with standard Markdown so GitHub renders it correctly
- preserve the setup, provider, and Gemini preview sections from the original documentation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dba71d05e083289788a69856f8a32f