### PR TITLE
feat: support curated recipe previews

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -27,6 +27,7 @@ import { parseIngredientInput, sanitizeIngredients } from './services/ingredient
 import { SparklesIcon, CameraIcon, BookOpenIcon, PulseIcon } from './components/icons';
 import { useLanguage } from './context/LanguageContext';
 import { estimateNutritionSummary } from './services/nutritionService';
+import { resolveManualPreviewImage } from './services/manualPreviewService';
 
 type ActiveView = 'intro' | 'pantry' | 'recipes' | 'nutrition' | 'journal';
 
@@ -549,12 +550,17 @@ const App: React.FC = () => {
             availableSet.has(normalizeIngredientName(ingredient))
           );
 
-          return {
+          const manualPreviewImage = resolveManualPreviewImage(recipe);
+          const baseRecommendation: RecipeRecommendation = {
             ...recipe,
             missingIngredients,
             matchedIngredients,
             isFullyMatched: missingIngredients.length === 0,
           };
+
+          return manualPreviewImage
+            ? { ...baseRecommendation, previewImage: manualPreviewImage }
+            : baseRecommendation;
         })
         .sort((a, b) => Number(a.isFullyMatched) === Number(b.isFullyMatched)
           ? a.missingIngredients.length - b.missingIngredients.length

--- a/camera-food-reciepe-main/components/RecipeModal.tsx
+++ b/camera-food-reciepe-main/components/RecipeModal.tsx
@@ -206,6 +206,25 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
     (recipe: RecipeRecommendation, options?: PreviewRequestOptions) => {
       const { force = false, clearImage = false, skipStatePriming = false } = options ?? {};
       const key = previewKeyForRecipe(recipe);
+      const manualPreviewImage = recipe.previewImage?.trim();
+
+      if (manualPreviewImage) {
+        setPreviews(prev => {
+          const previous = prev[key];
+          if (previous?.status === 'success' && previous.image === manualPreviewImage) {
+            return prev;
+          }
+          return {
+            ...prev,
+            [key]: {
+              status: 'success',
+              image: manualPreviewImage,
+            },
+          };
+        });
+        return;
+      }
+
       const current = previewsRef.current[key];
 
       if (
@@ -280,6 +299,24 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
   const handleRefreshPreview = useCallback(
     (recipe: RecipeRecommendation) => {
       const key = previewKeyForRecipe(recipe);
+
+      if (recipe.previewImage?.trim()) {
+        const manualPreviewImage = recipe.previewImage.trim();
+        setPreviews(prev => {
+          const previous = prev[key];
+          if (previous?.status === 'success' && previous.image === manualPreviewImage) {
+            return prev;
+          }
+          return {
+            ...prev,
+            [key]: {
+              status: 'success',
+              image: manualPreviewImage,
+            },
+          };
+        });
+        return;
+      }
 
       if (!isDesignPreviewSupported) {
         setPreviews(prev => ({

--- a/camera-food-reciepe-main/services/__tests__/manualPreviewService.test.ts
+++ b/camera-food-reciepe-main/services/__tests__/manualPreviewService.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { RecipeVideo } from '../../types';
+import {
+  hasManualPreview,
+  resolveManualPreviewImage,
+  type ManualPreviewLookup,
+} from '../manualPreviewService';
+
+const sampleLookup: ManualPreviewLookup = {
+  vid123: 'data:image/png;base64,video-sample',
+  'garlic butter pasta': 'data:image/png;base64,recipe-sample',
+};
+
+describe('manualPreviewService', () => {
+  it('resolves manual previews by YouTube video id', () => {
+    const videos: RecipeVideo[] = [
+      {
+        id: 'vid123',
+        title: 'Sample',
+        channelTitle: 'Channel',
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+        videoUrl: 'https://youtube.com/watch?v=vid123',
+      },
+    ];
+
+    const result = resolveManualPreviewImage({ recipeName: 'Any', videos }, sampleLookup);
+    expect(result).toBe(sampleLookup.vid123);
+  });
+
+  it('resolves manual previews by recipe name ignoring case', () => {
+    const result = resolveManualPreviewImage({ recipeName: 'Garlic Butter Pasta', videos: [] }, sampleLookup);
+    expect(result).toBe(sampleLookup['garlic butter pasta']);
+  });
+
+  it('reports whether a manual preview exists', () => {
+    expect(
+      hasManualPreview(
+        {
+          recipeName: 'Unknown Recipe',
+          videos: [],
+        },
+        sampleLookup
+      )
+    ).toBe(false);
+
+    expect(
+      hasManualPreview(
+        {
+          recipeName: 'Garlic Butter Pasta',
+          videos: [],
+        },
+        sampleLookup
+      )
+    ).toBe(true);
+  });
+});

--- a/camera-food-reciepe-main/services/manualPreviewService.ts
+++ b/camera-food-reciepe-main/services/manualPreviewService.ts
@@ -1,0 +1,53 @@
+import type { RecipeRecommendation, RecipeVideo } from '../types';
+
+export type ManualPreviewLookup = Record<string, string>;
+
+export const manualPreviewLookup: ManualPreviewLookup = {
+  // Add curated recipe previews here using stable keys.
+};
+
+const normalizeRecipeName = (name: string) => name.trim().toLowerCase();
+
+const collectCandidateKeys = (recipe: { recipeName: string; videos?: RecipeVideo[] }): string[] => {
+  const candidates: string[] = [];
+  if (recipe.videos && recipe.videos.length > 0) {
+    for (const video of recipe.videos) {
+      const id = video?.id?.trim();
+      if (id) {
+        candidates.push(id);
+      }
+    }
+  }
+
+  const recipeName = recipe.recipeName?.trim();
+  if (recipeName) {
+    candidates.push(normalizeRecipeName(recipeName));
+  }
+
+  return candidates;
+};
+
+export const resolveManualPreviewImage = (
+  recipe: Pick<RecipeRecommendation, 'recipeName' | 'videos'>,
+  lookup: ManualPreviewLookup = manualPreviewLookup
+): string | undefined => {
+  const candidates = collectCandidateKeys(recipe);
+  for (const key of candidates) {
+    const directMatch = lookup[key];
+    if (directMatch) {
+      return directMatch;
+    }
+
+    const normalizedKey = normalizeRecipeName(key);
+    if (normalizedKey !== key && lookup[normalizedKey]) {
+      return lookup[normalizedKey];
+    }
+  }
+  return undefined;
+};
+
+export const hasManualPreview = (
+  recipe: Pick<RecipeRecommendation, 'recipeName' | 'videos'>,
+  lookup: ManualPreviewLookup = manualPreviewLookup
+): boolean => Boolean(resolveManualPreviewImage(recipe, lookup));
+


### PR DESCRIPTION
## Summary
- add a manual preview service that maps stable recipe keys to curated images
- propagate manual preview images through recipe recommendations and modal rendering
- guard preview refresh logic and cover manual preview resolution with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dba6b2a2388328ae99efb970a5e3c5