### PR TITLE
Fix YouTube error propagation in recipe flow

### DIFF
--- a/camera-food-reciepe-main/services/__tests__/videoService.test.ts
+++ b/camera-food-reciepe-main/services/__tests__/videoService.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  } else {
+    // @ts-expect-error - allow clearing fetch when not available
+    delete globalThis.fetch;
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  } else {
+    // @ts-expect-error - allow clearing fetch when not available
+    delete globalThis.fetch;
+  }
+});
+
+describe('getRecipeVideos', () => {
+  it('throws error_youtube_api_key when API key is missing', async () => {
+    vi.stubEnv('YOUTUBE_API_KEY', '');
+    vi.stubEnv('API_KEY', '');
+
+    const { getRecipeVideos } = await import('../videoService');
+
+    await expect(getRecipeVideos('Kimchi Stew', [])).rejects.toThrowError(
+      new Error('error_youtube_api_key')
+    );
+  });
+
+  it('throws error_youtube_fetch when YouTube search response is not ok', async () => {
+    vi.stubEnv('YOUTUBE_API_KEY', 'test-key');
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: false } as Response);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { getRecipeVideos } = await import('../videoService');
+
+    await expect(getRecipeVideos('Bibimbap', [])).rejects.toThrowError(new Error('error_youtube_fetch'));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws error_youtube_fetch when the fetch call rejects', async () => {
+    vi.stubEnv('YOUTUBE_API_KEY', 'test-key');
+    const fetchError = new Error('network failure');
+    const fetchSpy = vi.fn().mockRejectedValue(fetchError);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { getRecipeVideos } = await import('../videoService');
+
+    await expect(getRecipeVideos('Tteokbokki', [])).rejects.toThrowError(new Error('error_youtube_fetch'));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/camera-food-reciepe-main/services/videoService.ts
+++ b/camera-food-reciepe-main/services/videoService.ts
@@ -104,8 +104,8 @@ const scoreVideo = (title: string | undefined, recipeName: string, ingredients: 
 
 export async function getRecipeVideos(recipeName: string, ingredients: string[], maxResults = 4): Promise<RecipeVideo[]> {
   if (!YOUTUBE_API_KEY) {
-    console.warn('YOUTUBE_API_KEY (or API_KEY) environment variable is not set. No recipe videos will be returned.');
-    return [];
+    console.warn('YOUTUBE_API_KEY (or API_KEY) environment variable is not set.');
+    throw new Error('error_youtube_api_key');
   }
 
   try {
@@ -220,6 +220,13 @@ export async function getRecipeVideos(recipeName: string, ingredients: string[],
 
     return rankedVideos;
   } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message === 'error_youtube_fetch' || error.message === 'error_youtube_api_key')
+    ) {
+      throw error;
+    }
+
     console.error('Error fetching or verifying YouTube videos', error);
     throw new Error('error_youtube_fetch');
   }


### PR DESCRIPTION
## Summary
- throw `error_youtube_api_key` when YouTube credentials are missing and preserve fetch failure errors
- propagate video enrichment failures so recipe fetching surfaces translated YouTube issues
- add Vitest coverage for missing API key and fetch rejection scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbf390aaf4832893efdbd2ea79426a