### PR TITLE
Ensure error translations fall back to default message

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -156,6 +156,11 @@ const App: React.FC = () => {
   >({});
   const [videoAvailabilityNotice, setVideoAvailabilityNotice] = useState<string | null>(null);
 
+  const translateError = (messageKey: string) => {
+    const translated = t(messageKey as any);
+    return translated || t('errorUnknown');
+  };
+
   useEffect(() => {
     setRecipeMemories(current => {
       if (!current.some(memory => typeof memory.journalPreviewImage === 'undefined')) {
@@ -570,7 +575,7 @@ const App: React.FC = () => {
     } catch (err) {
       const messageKey = err instanceof Error ? err.message : 'errorUnknown';
       setRecipes([]);
-      setError(t(messageKey as any));
+      setError(translateError(messageKey));
       setVideoAvailabilityNotice(null);
     } finally {
       setIsLoadingRecipes(false);
@@ -650,7 +655,7 @@ const App: React.FC = () => {
       const messageKey = err instanceof Error ? err.message : 'errorPhotoAnalysis';
       setSelectedIngredients([]);
       setRecipes([]);
-      setError(t(messageKey as any));
+      setError(translateError(messageKey));
       setVideoAvailabilityNotice(null);
       setRecipeModalOpen(true);
       setNutritionSummary(null);


### PR DESCRIPTION
## Summary
- add a translateError helper to centralize fallback logic for localized errors
- apply the helper in recipe fetch and camera capture flows to maintain readable messages

## Testing
- npm run test
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc0079647883289a967a8a62b85948