### PR TITLE
feat: persist recipe video selections in journal memories

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -332,7 +332,11 @@ const App: React.FC = () => {
     })();
   };
 
-  const handleSaveRecipeMemory = (recipe: RecipeRecommendation) => {
+  const handleSaveRecipeMemory = (recipe: RecipeRecommendation, selectedVideoId: string | null) => {
+    const selectedVideoIsFromRecipe = selectedVideoId
+      ? recipe.videos.some(video => video.id === selectedVideoId)
+      : false;
+    const normalizedSelectedVideoId = selectedVideoIsFromRecipe ? selectedVideoId : null;
     const normalizedName = recipe.recipeName.trim().toLowerCase();
     const existing = recipeMemories.find(
       memory => memory.recipeName.trim().toLowerCase() === normalizedName
@@ -341,15 +345,20 @@ const App: React.FC = () => {
     if (existing) {
       const needsEnrichment =
         !existing.ingredients?.length || !existing.instructions?.length || !existing.videos?.length;
-      if (needsEnrichment) {
+      if (needsEnrichment || existing.selectedVideoId !== normalizedSelectedVideoId) {
         setRecipeMemories(current =>
           current.map(memory =>
             memory.id === existing.id
               ? {
                   ...memory,
-                  ingredients: recipe.ingredientsNeeded,
-                  instructions: recipe.instructions,
-                  videos: recipe.videos,
+                  selectedVideoId: normalizedSelectedVideoId,
+                  ...(needsEnrichment
+                    ? {
+                        ingredients: recipe.ingredientsNeeded,
+                        instructions: recipe.instructions,
+                        videos: recipe.videos,
+                      }
+                    : {}),
                 }
               : memory
           )
@@ -375,6 +384,7 @@ const App: React.FC = () => {
       ingredients: recipe.ingredientsNeeded,
       instructions: recipe.instructions,
       videos: recipe.videos,
+      selectedVideoId: normalizedSelectedVideoId,
       journalPreviewImage: null,
     };
 

--- a/camera-food-reciepe-main/components/RecipeExperienceModal.tsx
+++ b/camera-food-reciepe-main/components/RecipeExperienceModal.tsx
@@ -27,6 +27,22 @@ const RecipeExperienceModal: React.FC<RecipeExperienceModalProps> = ({ entry, on
 
   const instructions = entry.instructions ?? [];
   const videos = entry.videos ?? [];
+  const selectedVideoId = entry.selectedVideoId ?? null;
+  const selectedVideo = useMemo(
+    () => (selectedVideoId ? videos.find(video => video.id === selectedVideoId) ?? null : null),
+    [videos, selectedVideoId]
+  );
+
+  const videoSectionHeading = selectedVideo
+    ? t('experienceModalVideosTitleSelected', { title: selectedVideo.title })
+    : t('experienceModalVideosTitle');
+
+  const videoSectionSubtitle = selectedVideo
+    ? t('experienceModalVideosSubtitleSelected', {
+        title: selectedVideo.title,
+        channel: selectedVideo.channelTitle,
+      })
+    : t('experienceModalVideosSubtitle');
 
   const nutritionSummary = useMemo(() => {
     if (!ingredients.length) {
@@ -181,9 +197,12 @@ const RecipeExperienceModal: React.FC<RecipeExperienceModalProps> = ({ entry, on
           </section>
 
           <section className="space-y-4">
-            <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-widest">
-              {t('experienceModalVideosTitle')}
-            </h3>
+            <div className="space-y-1">
+              <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-widest">
+                {videoSectionHeading}
+              </h3>
+              <p className="text-xs text-gray-500">{videoSectionSubtitle}</p>
+            </div>
             {videos.length > 0 ? (
               <div className="grid gap-4 md:grid-cols-2">
                 {videos.map(video => (
@@ -192,7 +211,11 @@ const RecipeExperienceModal: React.FC<RecipeExperienceModalProps> = ({ entry, on
                     href={video.videoUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="group block bg-gray-100 rounded-xl overflow-hidden shadow-sm hover:shadow-lg transition-shadow"
+                    className={`group block rounded-xl overflow-hidden bg-gray-100 shadow-sm transition-shadow border ${
+                      selectedVideoId === video.id
+                        ? 'border-brand-orange/60 ring-2 ring-brand-orange shadow-lg'
+                        : 'border-transparent hover:shadow-lg'
+                    }`}
                   >
                     <div className="relative aspect-video overflow-hidden">
                       <img src={video.thumbnailUrl} alt={video.title} className="w-full h-full object-cover group-hover:scale-105 transition-transform" />

--- a/camera-food-reciepe-main/components/__tests__/RecipeModal.test.tsx
+++ b/camera-food-reciepe-main/components/__tests__/RecipeModal.test.tsx
@@ -29,7 +29,7 @@ describe('RecipeModal', () => {
           isLoading={false}
           error={null}
           ingredients={['마늘']}
-          onSaveRecipeToJournal={() => ({ id: '1', isNew: true })}
+          onSaveRecipeToJournal={(_, __) => ({ id: '1', isNew: true })}
           savedRecipeNames={[]}
           nutritionSummary={null}
           nutritionContext={null}

--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -113,7 +113,12 @@ export const recipeModalNoExtraIngredients = '추가로 필요한 재료가 없�
 export const recipeModalStepByStepTitle = '이 순서대로 천천히 따라오세요';
 export const recipeModalStepByStepSubtitle = '큰 동작은 위에, 필요한 팁은 아래에 정리했어요.';
 export const recipeModalStepByStepHint = '카드를 순서대로 따라가면 부담 없이 완성돼요.';
-export const recipeModalWatchVideos = '영상으로 따라해보세요';
+export const recipeModalWatchVideosHeadingDefault = '영상으로 따라해보세요';
+export const recipeModalWatchVideosHeadingSelected = '선택한 영상: {{title}}';
+export const recipeModalWatchVideosSubtitleDefault =
+  '마음에 드는 YouTube 영상을 골라 새 탭에서 바로 시청해보세요.';
+export const recipeModalWatchVideosSubtitleSelected =
+  '{{channel}} 채널의 "{{title}}" 영상을 열었어요. 영상과 함께 요리를 이어가보세요.';
 export const recipeModalNoVideos = '적절한 영상을 찾지 못했어요. 다른 레시피를 선택해보세요.';
 export const recipeModalNoResults = '추천 결과가 없어요. 재료를 조금만 더 추가해보세요!';
 export const recipeModalClose = '닫기';
@@ -249,4 +254,8 @@ export const experienceModalStepsTitle = '요리 순서';
 export const experienceModalStepsSubtitle = '실제 요리할 때 참고할 요약본이에요.';
 export const experienceModalStepsEmpty = '저장된 조리 단계가 없어요. 상세 레시피 링크를 통해 확인해주세요.';
 export const experienceModalVideosTitle = '함께 저장된 영상';
+export const experienceModalVideosTitleSelected = '저장해 둔 영상: {{title}}';
+export const experienceModalVideosSubtitle = '저장된 영상 링크를 눌러 새 탭에서 바로 재생할 수 있어요.';
+export const experienceModalVideosSubtitleSelected =
+  '{{channel}} 채널의 "{{title}}" 영상을 저장해두었어요. 다시 보고 따라 해보세요.';
 export const experienceModalVideosEmpty = '저장된 영상이 없어요. 레시피 카드의 링크에서 다른 영상을 찾아보세요.';

--- a/camera-food-reciepe-main/types.ts
+++ b/camera-food-reciepe-main/types.ts
@@ -93,6 +93,7 @@ export interface RecipeMemory {
     ingredients?: string[];
     instructions?: string[];
     videos?: RecipeVideo[];
+    selectedVideoId?: string | null;
     journalPreviewImage?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- add UI state in the recipe modal so picking a YouTube card highlights the choice and updates the copy
- persist the chosen video id when saving a recipe memory and surface the selection inside the experience modal
- expand Korean locale strings to describe the selected video in both modals

## Testing
- npm run test
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dc051fe6c48328a8d8b871dd080e61