### PR TITLE
Fix Gemini recipe prompt payload

### DIFF
--- a/camera-food-reciepe-main/services/geminiService.ts
+++ b/camera-food-reciepe-main/services/geminiService.ts
@@ -52,7 +52,12 @@ export async function getRecipeSuggestions(ingredients: string[]): Promise<Recip
     try {
         const response = await ai.models.generateContent({
             model: 'gemini-2.5-flash',
-            contents: prompt,
+            contents: [
+                {
+                    role: 'user',
+                    parts: [{ text: prompt }],
+                },
+            ],
             config: {
                 responseMimeType: 'application/json',
                 responseSchema: recipeSchema,


### PR DESCRIPTION
## Summary
- send the Gemini recipe suggestion request as a structured user message so the SDK can parse the prompt reliably

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc3c568f8832893769cb58de6e7e0