### PR TITLE
fix: make useLocalStorage SSR-safe

### DIFF
--- a/camera-food-reciepe-main/hooks/useLocalStorage.ts
+++ b/camera-food-reciepe-main/hooks/useLocalStorage.ts
@@ -3,6 +3,10 @@ import { useState, useEffect } from 'react';
 
 export function useLocalStorage<T,>(key: string, initialValue: T): [T, React.Dispatch<React.SetStateAction<T>>] {
   const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+
     try {
       const item = window.localStorage.getItem(key);
       return item ? JSON.parse(item) : initialValue;
@@ -13,27 +17,65 @@ export function useLocalStorage<T,>(key: string, initialValue: T): [T, React.Dis
   });
 
   const setValue = (value: T | ((val: T) => T)) => {
+    setStoredValue(prevValue => {
+      const valueToStore = typeof value === 'function' ? (value as (val: T) => T)(prevValue) : value;
+
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem(key, JSON.stringify(valueToStore));
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
+      return valueToStore;
+    });
+  };
+
+  // This effect listens for changes in other tabs
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const parseStoredValue = (value: string) => {
+      try {
+        return JSON.parse(value) as T;
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    };
+
     try {
-      const valueToStore = value instanceof Function ? value(storedValue) : value;
-      setStoredValue(valueToStore);
-      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      const existingValue = window.localStorage.getItem(key);
+      if (existingValue !== null) {
+        const parsed = parseStoredValue(existingValue);
+        if (parsed !== null) {
+          setStoredValue(parsed);
+        }
+      }
     } catch (error) {
       console.error(error);
     }
-  };
-  
-  // This effect listens for changes in other tabs
-  useEffect(() => {
+
     const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === key && e.newValue) {
-        setStoredValue(JSON.parse(e.newValue));
+      if (e.key === key) {
+        if (e.newValue !== null) {
+          const parsed = parseStoredValue(e.newValue);
+          if (parsed !== null) {
+            setStoredValue(parsed);
+          }
+        } else {
+          setStoredValue(initialValue);
+        }
       }
     };
     window.addEventListener('storage', handleStorageChange);
     return () => {
       window.removeEventListener('storage', handleStorageChange);
     };
-  }, [key]);
+  }, [initialValue, key]);
 
   return [storedValue, setValue];
 }


### PR DESCRIPTION
## Summary
- guard the localStorage hook against missing window during server rendering
- synchronize state when storage is cleared and add resilient parsing for cross-tab updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc3c7630083288837a6d00d48fae0