### PR TITLE
Add video-driven recipe selection flow

### DIFF
--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -112,7 +112,16 @@ export const recipeModalStepByStepTitle = '이 순서대로 천천히 따라오�
 export const recipeModalStepByStepSubtitle = '큰 동작은 위에, 필요한 팁은 아래에 정리했어요.';
 export const recipeModalStepByStepHint = '카드를 순서대로 따라가면 부담 없이 완성돼요.';
 export const recipeModalWatchVideos = '영상으로 따라해보세요';
+export const recipeModalWatchVideosHint = '마음에 드는 영상을 눌러 레시피를 바로 불러와보세요.';
 export const recipeModalNoVideos = '적절한 영상을 찾지 못했어요. 다른 레시피를 선택해보세요.';
+export const recipeModalVideoSelected = '선택됨';
+export const recipeModalVideoProvidersLabel = '영상 채널';
+export const recipeModalVideoRecipeTitle = '영상 기반 레시피 정리';
+export const recipeModalVideoRecipeSubtitle = '{{channel}} 채널 영상 흐름을 토대로 정리했어요.';
+export const recipeModalVideoRecipeSubtitleIdle = '관심 있는 영상을 선택하면 영상 중심으로 레시피를 재구성해드려요.';
+export const recipeModalVideoRecipeLoading = '영상에 맞춰 레시피를 정리하고 있어요...';
+export const recipeModalVideoRecipeIngredients = '영상에서 언급된 핵심 재료';
+export const recipeModalVideoRecipeSteps = '영상 흐름 요약 단계';
 export const recipeModalNoResults = '추천 결과가 없어요. 재료를 조금만 더 추가해보세요!';
 export const recipeModalClose = '닫기';
 export const recipeModalAllIngredientsOnHand = '필요한 재료가 모두 냉장고에 준비되어 있어요.';
@@ -187,6 +196,9 @@ export const error_youtube_api_key = 'YouTube API 키가 설정되지 않았어�
 export const error_youtube_fetch = '레시피 영상을 불러오지 못했어요. 잠시 후 다시 시도해주세요.';
 export const error_vision_api_url = '이미지 인식 서비스가 아직 연결되지 않았어요. VISION_API_URL 환경 변수를 설정해주세요.';
 export const error_vision_fetch = '이미지에서 재료를 분석하는 데 실패했어요. 잠시 후 다시 시도해주세요.';
+export const errorGeminiVideoRecipe =
+  '영상 기반 레시피를 만들려면 Gemini API 키가 필요해요. 환경 변수를 확인한 뒤 다시 시도해주세요.';
+export const errorVideoRecipeUnavailable = '영상을 기반으로 한 레시피를 정리하지 못했어요. 다른 영상을 선택하거나 잠시 후 다시 시도해주세요.';
 
 export const journalSectionTitle = '나의 요리 기록';
 export const journalSectionDescription = '실제로 만들어본 요리를 저장하고 다음에 참고할 메모를 남겨보세요.';

--- a/camera-food-reciepe-main/services/videoRecipeService.ts
+++ b/camera-food-reciepe-main/services/videoRecipeService.ts
@@ -1,0 +1,127 @@
+import { GoogleGenAI, Type } from '@google/genai';
+import type { Recipe, RecipeRecommendation, RecipeVideo } from '../types';
+
+const GEMINI_API_KEY =
+  (process.env.GEMINI_API_KEY as string | undefined) ?? (process.env.API_KEY as string | undefined);
+
+const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
+
+const videoRecipeSchema = {
+  type: Type.OBJECT,
+  properties: {
+    recipeName: {
+      type: Type.STRING,
+      description: 'Name of the dish featured in the selected video.',
+    },
+    description: {
+      type: Type.STRING,
+      description: 'A short summary that reflects the tone of the referenced video.',
+    },
+    ingredientsNeeded: {
+      type: Type.ARRAY,
+      description:
+        'Ordered list of additional ingredients (beyond the detected pantry items) required to follow the selected video.',
+      items: {
+        type: Type.STRING,
+      },
+    },
+    instructions: {
+      type: Type.ARRAY,
+      description:
+        'Step-by-step cooking instructions distilled from the video. Each step must be concise and actionable.',
+      items: {
+        type: Type.STRING,
+      },
+    },
+  },
+  required: ['recipeName', 'description', 'ingredientsNeeded', 'instructions'],
+} as const;
+
+interface GenerateVideoRecipeOptions {
+  video: RecipeVideo;
+  baseRecipe?: RecipeRecommendation | null;
+  pantryIngredients?: string[];
+}
+
+export async function generateVideoRecipe({
+  video,
+  baseRecipe = null,
+  pantryIngredients = [],
+}: GenerateVideoRecipeOptions): Promise<Recipe> {
+  if (!ai || !GEMINI_API_KEY) {
+    throw new Error('error_gemini_api_key');
+  }
+
+  const videoTitle = video.title.trim();
+  const channelTitle = video.channelTitle.trim();
+  const videoUrl = video.videoUrl.trim();
+
+  const baseIngredients = (baseRecipe?.ingredientsNeeded ?? []).filter(Boolean);
+  const baseInstructions = (baseRecipe?.instructions ?? []).filter(step => step && step.trim().length > 0);
+  const pantryList = pantryIngredients.filter(Boolean);
+
+  const baseInstructionText =
+    baseInstructions.length > 0
+      ? baseInstructions.map((step, index) => `${index + 1}. ${step.trim()}`).join('\n')
+      : '없음';
+
+  const prompt = `당신은 요리 영상을 텍스트 레시피로 정리하는 어시스턴트입니다.\n\n` +
+    `선택된 영상 정보:\n- 제목: ${videoTitle}\n- 채널: ${channelTitle}\n- URL: ${videoUrl}\n\n` +
+    `사용자가 사용할 수 있는 재료: ${pantryList.length > 0 ? pantryList.join(', ') : '주요 재료 정보 없음'}\n` +
+    `기존 추천 레시피에서 참고할 수 있는 추가 재료: ${
+      baseIngredients.length > 0 ? baseIngredients.join(', ') : '정보 없음'
+    }\n` +
+    `기존 추천 레시피의 단계:\n${baseInstructionText}\n\n` +
+    '영상을 실제로 본 것처럼 자연스러운 톤으로 작성하되, 가정에서 따라 할 수 있도록 세부 단계를 분명하게 정리하세요. ' +
+    '각 단계는 반드시 명령문으로 시작하고, 영상에서 강조할 만한 팁이나 주의사항이 있다면 간단히 덧붙입니다. ' +
+    '추가 재료 목록은 영상에서 언급할 법한 기본 재료 위주로 구성하고, 중복되거나 이미 사용자가 가지고 있는 재료는 제외하세요. ' +
+    '응답은 JSON 형식으로만 반환합니다.';
+
+  try {
+    const response = await ai.models.generateContent({
+      model: 'gemini-2.5-flash',
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: prompt }],
+        },
+      ],
+      config: {
+        responseMimeType: 'application/json',
+        responseSchema: videoRecipeSchema,
+        temperature: 0.6,
+      },
+    });
+
+    let jsonText: string | undefined = response.text;
+
+    if (!jsonText) {
+      const fallback = (response as { output_text?: string | undefined }).output_text;
+      if (typeof fallback === 'string') {
+        jsonText = fallback;
+      }
+    }
+
+    const trimmed = jsonText?.trim();
+    if (!trimmed) {
+      throw new Error('error_video_recipe_fetch');
+    }
+
+    const recipe = JSON.parse(trimmed) as Recipe;
+    return {
+      ...recipe,
+      ingredientsNeeded: Array.isArray(recipe.ingredientsNeeded)
+        ? recipe.ingredientsNeeded.map(entry => String(entry).trim()).filter(Boolean)
+        : [],
+      instructions: Array.isArray(recipe.instructions)
+        ? recipe.instructions.map(step => String(step).trim()).filter(Boolean)
+        : [],
+    };
+  } catch (error) {
+    console.error('Failed to generate recipe from video', error);
+    if (error instanceof Error && error.message === 'error_gemini_api_key') {
+      throw error;
+    }
+    throw new Error('error_video_recipe_fetch');
+  }
+}

--- a/camera-food-reciepe-main/types.ts
+++ b/camera-food-reciepe-main/types.ts
@@ -95,3 +95,11 @@ export interface RecipeMemory {
     videos?: RecipeVideo[];
     journalPreviewImage?: string | null;
 }
+
+export interface VideoRecipeState {
+    video: RecipeVideo | null;
+    recipe: Recipe | null;
+    baseRecipeName: string | null;
+    isLoading: boolean;
+    error: string | null;
+}


### PR DESCRIPTION
## Summary
- add video recipe selection state in the app and call Gemini to build recipes from a chosen video
- reorganize the recipe modal to highlight video grids/providers, surface loading/error states, and render video-aligned instructions
- extend shared types and Korean copy for the new video recipe experience

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dcd40f3c5083288300d09e9a46cf5f