### PR TITLE
feat: add video-powered recipe extraction

### DIFF
--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -113,6 +113,9 @@ export const recipeModalStepByStepSubtitle = '큰 동작은 위에, 필요한 �
 export const recipeModalStepByStepHint = '카드를 순서대로 따라가면 부담 없이 완성돼요.';
 export const recipeModalWatchVideos = '영상으로 따라해보세요';
 export const recipeModalNoVideos = '적절한 영상을 찾지 못했어요. 다른 레시피를 선택해보세요.';
+export const recipeModalVideoAnalyzeAction = '이 영상으로 레시피 정리';
+export const recipeModalVideoAnalyzeLoading = '영상에서 레시피를 분석 중...';
+export const recipeModalVideoAnalyzeApplied = '이 영상 내용을 반영했어요';
 export const recipeModalNoResults = '추천 결과가 없어요. 재료를 조금만 더 추가해보세요!';
 export const recipeModalClose = '닫기';
 export const recipeModalAllIngredientsOnHand = '필요한 재료가 모두 냉장고에 준비되어 있어요.';
@@ -183,8 +186,10 @@ export const errorNoVideoRecipes = 'YouTube 영상이 있는 레시피를 찾지
 export const error_gemini_api_key =
   'Gemini API 키가 설정되지 않았어요. GEMINI_API_KEY (또는 기존 API_KEY) 환경 변수를 확인해주세요.';
 export const error_gemini_fetch = '레시피를 불러오지 못했어요. 잠시 후 다시 시도해주세요.';
+export const error_gemini_video_recipe = '영상에서 레시피를 정리하지 못했어요. 잠시 후 다시 시도해주세요.';
 export const error_youtube_api_key = 'YouTube API 키가 설정되지 않았어요. YOUTUBE_API_KEY(또는 기존 API_KEY)를 입력하면 영상을 불러올 수 있어요.';
 export const error_youtube_fetch = '레시피 영상을 불러오지 못했어요. 잠시 후 다시 시도해주세요.';
+export const error_video_recipe_analysis = '영상에서 레시피를 만들지 못했어요. 잠시 후 다시 시도해주세요.';
 export const error_vision_api_url = '이미지 인식 서비스가 아직 연결되지 않았어요. VISION_API_URL 환경 변수를 설정해주세요.';
 export const error_vision_fetch = '이미지에서 재료를 분석하는 데 실패했어요. 잠시 후 다시 시도해주세요.';
 

--- a/camera-food-reciepe-main/services/videoRecipeService.ts
+++ b/camera-food-reciepe-main/services/videoRecipeService.ts
@@ -1,0 +1,259 @@
+import type { Recipe, RecipeVideo } from '../types';
+import { getRecipeFromVideoContext } from './geminiService';
+
+const YOUTUBE_API_KEY =
+  (process.env.YOUTUBE_API_KEY as string | undefined) ?? (process.env.API_KEY as string | undefined);
+
+interface YouTubeVideoSnippet {
+  title?: string;
+  description?: string;
+  channelTitle?: string;
+  tags?: string[];
+}
+
+interface YouTubeVideoItem {
+  id?: string;
+  snippet?: YouTubeVideoSnippet;
+}
+
+interface YouTubeVideosResponse {
+  items?: YouTubeVideoItem[];
+}
+
+interface YouTubeCaptionSnippet {
+  language?: string;
+  trackKind?: string;
+  name?: { simpleText?: string };
+}
+
+interface YouTubeCaptionItem {
+  id?: string;
+  snippet?: YouTubeCaptionSnippet;
+}
+
+interface YouTubeCaptionsResponse {
+  items?: YouTubeCaptionItem[];
+}
+
+const DESCRIPTION_LIMIT = 2000;
+const CAPTION_LIMIT = 6000;
+const FALLBACK_WORD_THRESHOLD = 120;
+
+const sanitizeMultiline = (text: string) =>
+  text
+    .replace(/\r/g, '')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+
+const truncate = (text: string, limit: number) => {
+  if (text.length <= limit) {
+    return text;
+  }
+  return text.slice(0, limit);
+};
+
+const uniqueSanitizedList = (values: string[]) => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  values
+    .map(value => value.trim())
+    .filter(Boolean)
+    .forEach(value => {
+      const key = value.toLowerCase();
+      if (seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      result.push(value);
+    });
+
+  return result;
+};
+
+const fetchVideoMetadata = async (videoId: string) => {
+  const params = new URLSearchParams({
+    id: videoId,
+    part: 'snippet',
+    key: YOUTUBE_API_KEY ?? '',
+    maxResults: '1',
+  });
+
+  const response = await fetch(`https://www.googleapis.com/youtube/v3/videos?${params.toString()}`);
+
+  if (!response.ok) {
+    throw new Error('error_youtube_fetch');
+  }
+
+  const data = (await response.json()) as YouTubeVideosResponse;
+  const item = data.items?.find(entry => entry?.id === videoId) ?? data.items?.[0];
+
+  if (!item) {
+    throw new Error('error_youtube_fetch');
+  }
+
+  return item.snippet ?? {};
+};
+
+const prioritizeCaptions = (items: YouTubeCaptionItem[]) => {
+  const preferredLanguages = ['ko', 'en'];
+
+  return [...items].sort((a, b) => {
+    const aLang = a.snippet?.language ?? '';
+    const bLang = b.snippet?.language ?? '';
+    const aLangIndex = preferredLanguages.indexOf(aLang);
+    const bLangIndex = preferredLanguages.indexOf(bLang);
+    const aAutoPenalty = a.snippet?.trackKind === 'ASR' ? 1 : 0;
+    const bAutoPenalty = b.snippet?.trackKind === 'ASR' ? 1 : 0;
+
+    const normalizedALang = aLangIndex === -1 ? preferredLanguages.length : aLangIndex;
+    const normalizedBLang = bLangIndex === -1 ? preferredLanguages.length : bLangIndex;
+
+    if (normalizedALang !== normalizedBLang) {
+      return normalizedALang - normalizedBLang;
+    }
+
+    if (aAutoPenalty !== bAutoPenalty) {
+      return aAutoPenalty - bAutoPenalty;
+    }
+
+    return 0;
+  });
+};
+
+const downloadCaptionTrack = async (captionId: string) => {
+  const formats = ['srv3', 'srv2', 'srv1', 'ttml', 'srt', 'vtt'];
+
+  for (const format of formats) {
+    try {
+      const response = await fetch(
+        `https://www.googleapis.com/youtube/v3/captions/${captionId}?${new URLSearchParams({
+          key: YOUTUBE_API_KEY ?? '',
+          tfmt: format,
+          alt: 'media',
+        }).toString()}`
+      );
+
+      if (!response.ok) {
+        continue;
+      }
+
+      const text = await response.text();
+      if (text.trim()) {
+        return sanitizeMultiline(text);
+      }
+    } catch (error) {
+      console.warn('Unable to download caption track', error);
+    }
+  }
+
+  return '';
+};
+
+const fetchCaptionText = async (videoId: string) => {
+  try {
+    const params = new URLSearchParams({
+      part: 'snippet',
+      videoId,
+      key: YOUTUBE_API_KEY ?? '',
+    });
+
+    const response = await fetch(`https://www.googleapis.com/youtube/v3/captions?${params.toString()}`);
+
+    if (!response.ok) {
+      return '';
+    }
+
+    const data = (await response.json()) as YouTubeCaptionsResponse;
+    const items = data.items ?? [];
+    if (items.length === 0) {
+      return '';
+    }
+
+    const prioritized = prioritizeCaptions(items);
+
+    for (const item of prioritized) {
+      if (!item.id) {
+        continue;
+      }
+
+      const text = await downloadCaptionTrack(item.id);
+      if (text) {
+        return truncate(text, CAPTION_LIMIT);
+      }
+    }
+  } catch (error) {
+    console.warn('Unable to fetch caption list', error);
+  }
+
+  return '';
+};
+
+export async function analyzeVideoRecipe(
+  video: RecipeVideo,
+  fallbackIngredients: string[]
+): Promise<Recipe> {
+  if (!YOUTUBE_API_KEY) {
+    throw new Error('error_youtube_api_key');
+  }
+
+  try {
+    const metadata = await fetchVideoMetadata(video.id);
+    const captionText = await fetchCaptionText(video.id);
+
+    const contextSections: string[] = [];
+
+    const title = metadata.title ?? video.title;
+    if (title) {
+      contextSections.push(`Video Title: ${title}`);
+    }
+
+    if (metadata.channelTitle ?? video.channelTitle) {
+      contextSections.push(`Channel: ${metadata.channelTitle ?? video.channelTitle}`);
+    }
+
+    if (metadata.description) {
+      const sanitizedDescription = truncate(sanitizeMultiline(metadata.description), DESCRIPTION_LIMIT);
+      if (sanitizedDescription) {
+        contextSections.push(`Description:\n${sanitizedDescription}`);
+      }
+    }
+
+    if (metadata.tags && metadata.tags.length > 0) {
+      contextSections.push(`Tags: ${uniqueSanitizedList(metadata.tags).join(', ')}`);
+    }
+
+    if (captionText) {
+      contextSections.push(`Transcript excerpt:\n${captionText}`);
+    }
+
+    const contextText = contextSections.join('\n\n').trim();
+    const sanitizedFallback = uniqueSanitizedList(fallbackIngredients);
+
+    const wordCount = contextText ? contextText.split(/\s+/).length : 0;
+    const shouldIncludeFallback = wordCount < FALLBACK_WORD_THRESHOLD && sanitizedFallback.length > 0;
+
+    const recipe = await getRecipeFromVideoContext({
+      videoId: video.id,
+      videoTitle: title,
+      channelTitle: metadata.channelTitle ?? video.channelTitle,
+      contextText,
+      fallbackIngredients: shouldIncludeFallback ? sanitizedFallback : [],
+    });
+
+    return {
+      ...recipe,
+      sourceVideoId: video.id,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('error_')) {
+      throw error;
+    }
+
+    console.error('Failed to analyze video recipe', error);
+    throw new Error('error_video_recipe_analysis');
+  }
+}

--- a/camera-food-reciepe-main/types.ts
+++ b/camera-food-reciepe-main/types.ts
@@ -27,6 +27,7 @@ export interface Recipe {
     description: string;
     ingredientsNeeded: string[];
     instructions: string[];
+    sourceVideoId?: string;
 }
 
 export interface RecipeVideo {
@@ -93,5 +94,6 @@ export interface RecipeMemory {
     ingredients?: string[];
     instructions?: string[];
     videos?: RecipeVideo[];
+    sourceVideoId?: string;
     journalPreviewImage?: string | null;
 }


### PR DESCRIPTION
## Summary
- add a video recipe service that collects YouTube metadata/captions and invokes Gemini to structure recipes
- extend Gemini tooling and shared types with video source tracking and integrate fallback ingredient handling
- wire the app and recipe modal to trigger video analysis with localized loading/error states

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dcd410fbac832897d54d601c6c6321