### PR TITLE
fix: normalize useLocalStorage for null entries

### DIFF
--- a/camera-food-reciepe-main/hooks/useLocalStorage.test.tsx
+++ b/camera-food-reciepe-main/hooks/useLocalStorage.test.tsx
@@ -1,0 +1,48 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+import { useLocalStorage } from './useLocalStorage';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('falls back to the initial value when localStorage returns "null"', () => {
+    vi.spyOn(window.localStorage, 'getItem').mockReturnValue('null');
+
+    let capturedValue: string[] = [];
+
+    const TestComponent = () => {
+      const [value] = useLocalStorage<string[]>('test-key', ['fallback']);
+      capturedValue = value;
+      return null;
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<TestComponent />);
+    });
+
+    expect(capturedValue).toEqual(['fallback']);
+
+    act(() => {
+      root.unmount();
+    });
+
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- coerce useLocalStorage values back to defaults when parsing null, undefined, or invalid JSON
- sanitize writes and storage event updates so only valid values are stored
- add a regression test that stubs localStorage returning "null" and verifies the fallback array is used

## Testing
- npm test
- npm run lint --if-present

------
https://chatgpt.com/codex/tasks/task_e_68dce3f748d883289fddb684033c4d92