### PR TITLE
Fix recipe modal video prompt scoping

### DIFF
--- a/camera-food-reciepe-main/components/RecipeModal.tsx
+++ b/camera-food-reciepe-main/components/RecipeModal.tsx
@@ -385,7 +385,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                     : null;
                 const providerVideos =
                   activeVideoRecipe?.videos?.length ? activeVideoRecipe.videos : recipe.videos;
-                const hasSelectedVideo = Boolean(videoRecipeState.selectedVideo);
+                const hasSelectedVideo = Boolean(selectedVideo);
                 const videoAlignedInstructions = activeVideoRecipe?.instructions ?? [];
                 const instructionsToDisplay =
                   hasSelectedVideo && videoAlignedInstructions.length > 0
@@ -409,7 +409,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                 const recipeForDisplay = activeVideoRecipe ?? recipe;
                 const shouldRenderInstructions = instructionsToDisplay.length > 0;
                 const shouldShowSelectVideoPrompt =
-                  providerVideos.length > 0 && !videoRecipeState.selectedVideo;
+                  providerVideos.length > 0 && !selectedVideo;
                 const showVideoStatusCard = isVideoTargeted || shouldShowSelectVideoPrompt;
 
                 return (


### PR DESCRIPTION
## Summary
- base the select video prompt state on each recipe's selected video
- ensure the recipe modal keeps showing the prompt for recipes without a picked video

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68de1f0226748328b0b9e0dae0472462