### PR TITLE
Expose transcript service env to client bundle

### DIFF
--- a/camera-food-reciepe-main/vite.config.ts
+++ b/camera-food-reciepe-main/vite.config.ts
@@ -13,6 +13,12 @@ export default defineConfig(({ mode }) => {
       'process.env.VITE_YOUTUBE_API_KEY': JSON.stringify(env.YOUTUBE_API_KEY ?? env.VITE_YOUTUBE_API_KEY),
       'process.env.VISION_API_URL': JSON.stringify(env.VISION_API_URL),
       'process.env.VISION_API_KEY': JSON.stringify(env.VISION_API_KEY),
+      'process.env.VIDEO_TRANSCRIPT_SERVICE_URL': JSON.stringify(
+        env.VIDEO_TRANSCRIPT_SERVICE_URL ?? env.VITE_VIDEO_TRANSCRIPT_SERVICE_URL,
+      ),
+      'process.env.VITE_VIDEO_TRANSCRIPT_SERVICE_URL': JSON.stringify(
+        env.VIDEO_TRANSCRIPT_SERVICE_URL ?? env.VITE_VIDEO_TRANSCRIPT_SERVICE_URL,
+      ),
     },
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- inject VIDEO_TRANSCRIPT_SERVICE_URL and its VITE-prefixed fallback into Vite's define block so the client bundle can resolve the transcript endpoint
- confirm the production build inlines the configured transcript service URL

## Testing
- npm run test
- npm run lint *(fails: script not defined)*
- VIDEO_TRANSCRIPT_SERVICE_URL=https://transcripts.example.com/api npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2bfb8dd4832895c1af62b0d34537