### PR TITLE
feat: add guidance cards when recipe details hidden

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -156,6 +156,7 @@ const App: React.FC = () => {
   const [recipes, setRecipes] = useState<RecipeRecommendation[]>([]);
   const [isLoadingRecipes, setIsLoadingRecipes] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorKey, setErrorKey] = useState<string | null>(null);
   const [isCameraOpen, setCameraOpen] = useState(false);
   const [isAnalyzingPhoto, setIsAnalyzingPhoto] = useState(false);
   const [selectedIngredients, setSelectedIngredients] = useState<string[]>([]);
@@ -563,6 +564,7 @@ const App: React.FC = () => {
 
   const fetchRecipesForIngredients = async (ingredients: string[], availableIngredientNames: string[]) => {
     setError(null);
+    setErrorKey(null);
     setIsLoadingRecipes(true);
     setVideoAvailabilityNotice(null);
     setVideoRecipe(null);
@@ -574,6 +576,7 @@ const App: React.FC = () => {
       const suggestions = await getRecipeSuggestions(ingredients);
       if (!suggestions.length) {
         setRecipes([]);
+        setErrorKey('errorNoRecipes');
         setError(t('errorNoRecipes'));
         return;
       }
@@ -599,6 +602,7 @@ const App: React.FC = () => {
       if (hasVideos && youtubeReady.length === 0) {
         setRecipes([]);
         setVideoAvailabilityNotice(null);
+        setErrorKey('errorNoVideoRecipes');
         setError(t('errorNoVideoRecipes'));
         return;
       }
@@ -639,6 +643,7 @@ const App: React.FC = () => {
       const messageKey = err instanceof Error ? err.message : 'errorUnknown';
       setRecipes([]);
       setError(translateError(messageKey));
+      setErrorKey(messageKey);
       setVideoAvailabilityNotice(null);
     } finally {
       setIsLoadingRecipes(false);
@@ -657,6 +662,7 @@ const App: React.FC = () => {
       setSelectedIngredients([]);
       setRecipes([]);
       setVideoAvailabilityNotice(null);
+      setErrorKey('errorScanFirst');
       setError(t('errorScanFirst'));
       setRecipeModalOpen(true);
       return;
@@ -671,6 +677,7 @@ const App: React.FC = () => {
     if (sanitizedTopIngredients.length === 0) {
       setSelectedIngredients([]);
       setRecipes([]);
+      setErrorKey('errorScanFirst');
       setError(t('errorScanFirst'));
       setRecipeModalOpen(true);
       return;
@@ -686,6 +693,7 @@ const App: React.FC = () => {
 
     try {
       setError(null);
+      setErrorKey(null);
       setMoodboardError(null);
       const detectedIngredients = await analyzeIngredientsFromImage(photo);
       const sanitizedDetectedIngredients = sanitizeIngredients(detectedIngredients ?? []);
@@ -723,6 +731,7 @@ const App: React.FC = () => {
       setSelectedIngredients([]);
       setRecipes([]);
       setError(translateError(messageKey));
+      setErrorKey(messageKey);
       setVideoAvailabilityNotice(null);
       setRecipeModalOpen(true);
       setNutritionSummary(null);
@@ -1092,6 +1101,8 @@ const App: React.FC = () => {
     }
   };
 
+  const shouldHideRecipeDetails = errorKey === 'errorScanFirst';
+
   const toolbarActions = [
     {
       key: 'scan',
@@ -1276,6 +1287,7 @@ const App: React.FC = () => {
               ? videoGuideState.recipe.recipeName
               : null
           }
+          shouldHideRecipeDetails={shouldHideRecipeDetails}
         />
       )}
 

--- a/camera-food-reciepe-main/components/RecipeModal.tsx
+++ b/camera-food-reciepe-main/components/RecipeModal.tsx
@@ -6,7 +6,7 @@ import type {
   RecipeVideo,
 } from '../types';
 import type { TranscriptPromptStatus } from '../services/geminiService';
-import { UtensilsIcon, PulseIcon } from './icons';
+import { UtensilsIcon, PulseIcon, CameraIcon, SparklesIcon, BookOpenIcon } from './icons';
 import { useLanguage } from '../context/LanguageContext';
 import { formatMacro } from '../services/nutritionService';
 import { parseIngredientInput } from '../services/ingredientParser';
@@ -85,6 +85,7 @@ interface RecipeModalProps {
   onVideoSelect: (recipe: RecipeRecommendation, video: RecipeVideo) => void;
   videoRecipeState: VideoRecipeState;
   activeVideoGuideRecipeName?: string | null;
+  shouldHideRecipeDetails?: boolean;
 }
 
 const LoadingSkeleton: React.FC = () => (
@@ -113,6 +114,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
   onVideoSelect,
   videoRecipeState,
   activeVideoGuideRecipeName = null,
+  shouldHideRecipeDetails = false,
 }) => {
   const { t } = useLanguage();
   if (!isOpen) return null;
@@ -173,6 +175,32 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
         ? t('nutritionContextRecipe', { name: nutritionContext.label })
         : t('nutritionContextMemory', { name: nutritionContext.label })
     : null;
+
+  const guidanceCards = useMemo(
+    () => [
+      {
+        key: 'scan',
+        icon: <CameraIcon />,
+        title: t('recipeModalGuidanceCardScanTitle'),
+        description: t('recipeModalGuidanceCardScanDescription'),
+      },
+      {
+        key: 'ideas',
+        icon: <SparklesIcon />,
+        title: t('recipeModalGuidanceCardIdeasTitle'),
+        description: t('recipeModalGuidanceCardIdeasDescription'),
+      },
+      {
+        key: 'journal',
+        icon: <BookOpenIcon />,
+        title: t('recipeModalGuidanceCardJournalTitle'),
+        description: t('recipeModalGuidanceCardJournalDescription'),
+      },
+    ],
+    [t]
+  );
+
+  const shouldShowGuidance = shouldHideRecipeDetails && !isLoading;
 
   const handleSaveToJournal = (recipe: RecipeRecommendation) => {
     const isVideoEnhanced = videoRecipeState.recipe?.recipeName === recipe.recipeName;
@@ -384,7 +412,36 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
             </div>
           )}
 
-          {!isLoading && !error && recipes.length > 0 && (
+          {shouldShowGuidance && (
+            <section className="space-y-4">
+              <div className="rounded-2xl border border-brand-blue/20 bg-white/90 p-5 shadow-sm">
+                <h3 className="text-lg font-semibold text-brand-blue">
+                  {t('recipeModalGuidanceTitle')}
+                </h3>
+                <p className="mt-1 text-sm text-brand-blue/70">
+                  {t('recipeModalGuidanceSubtitle')}
+                </p>
+              </div>
+              <div className="grid gap-4 md:grid-cols-3">
+                {guidanceCards.map(card => (
+                  <div
+                    key={card.key}
+                    className="flex flex-col gap-3 rounded-2xl border border-brand-blue/15 bg-white/80 p-5 shadow-sm"
+                  >
+                    <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-brand-blue/10 text-brand-blue">
+                      {card.icon}
+                    </span>
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold text-gray-800">{card.title}</p>
+                      <p className="text-xs leading-relaxed text-gray-600">{card.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {!isLoading && !error && recipes.length > 0 && !shouldHideRecipeDetails && (
             <div className="space-y-6">
               {recipes.map((recipe, index) => {
                 const normalizedName = recipe.recipeName.trim().toLowerCase();
@@ -735,7 +792,7 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
             </div>
           )}
 
-          {!isLoading && !error && recipes.length === 0 && (
+          {!isLoading && !error && recipes.length === 0 && !shouldHideRecipeDetails && (
             <p className="text-gray-500 text-center py-10">{t('recipeModalNoResults')}</p>
           )}
         </div>

--- a/camera-food-reciepe-main/components/__tests__/RecipeModal.test.tsx
+++ b/camera-food-reciepe-main/components/__tests__/RecipeModal.test.tsx
@@ -19,6 +19,8 @@ import {
   recipeModalStepByStepCautionTitle,
   recipeModalStepByStepCautionSubtitle,
   recipeModalStepByStepCautionHint,
+  recipeModalGuidanceTitle,
+  recipeModalGuidanceCardScanTitle,
 } from '../../locales/ko';
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -60,6 +62,7 @@ const baseProps: RecipeModalProps = {
     transcript: { status: 'idle', messageKey: null },
   },
   activeVideoGuideRecipeName: null,
+  shouldHideRecipeDetails: false,
 };
 
 const renderModal = (override: Partial<RecipeModalProps>) => {
@@ -317,6 +320,22 @@ describe('RecipeModal', () => {
       expect(textContent).toContain(recipeModalStepByStepCautionSubtitle);
       expect(textContent).toContain(recipeModalStepByStepCautionHint);
       expect(textContent).not.toContain(recipeModalStepByStepTitle);
+    } finally {
+      unmount();
+    }
+  });
+
+  it('renders guidance cards when recipe details are hidden', () => {
+    const { container, unmount } = renderModal({
+      shouldHideRecipeDetails: true,
+      recipes: [baseRecipe],
+    });
+
+    try {
+      const textContent = container.textContent ?? '';
+      expect(textContent).toContain(recipeModalGuidanceTitle);
+      expect(textContent).toContain(recipeModalGuidanceCardScanTitle);
+      expect(textContent).not.toContain(baseRecipe.recipeName);
     } finally {
       unmount();
     }

--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -143,6 +143,18 @@ export const recipeModalProviderNoVideos = 'YouTube 영상 링크를 찾지 못�
 export const recipeModalProviderYoutubeLabel = 'YouTube';
 export const recipeModalRecipeNutritionHint = '이 레시피에 맞춘 영양 추정을 바로 확인해보세요.';
 export const recipeModalRecipeNutritionButton = '이 레시피 영양 보기';
+export const recipeModalGuidanceTitle = '레시피 추천을 준비 중이에요';
+export const recipeModalGuidanceSubtitle =
+  '재료를 인식하거나 입력하면 레시피 카드가 나타납니다. 아래 안내를 참고해 준비해보세요.';
+export const recipeModalGuidanceCardScanTitle = '재료 스캔하기';
+export const recipeModalGuidanceCardScanDescription =
+  '카메라로 냉장고를 촬영하면 필요한 재료가 자동으로 정리돼요.';
+export const recipeModalGuidanceCardIdeasTitle = '직접 재료 입력하기';
+export const recipeModalGuidanceCardIdeasDescription =
+  '떠오르는 재료를 입력해 맞춤 추천의 정확도를 높여보세요.';
+export const recipeModalGuidanceCardJournalTitle = '나만의 기록 만들기';
+export const recipeModalGuidanceCardJournalDescription =
+  '마음에 드는 조합을 찾으면 기록에 저장해 다음에도 빠르게 찾아보세요.';
 
 export const videoGuideWindowTitle = '{{recipe}} · {{title}}';
 export const videoGuideWindowSubtitle = '{{channel}} 채널 영상을 보며 단계별로 따라오세요.';


### PR DESCRIPTION
## Summary
- add a guidance-only mode for the recipe modal and skip rendering recipe cards when active
- track recipe error keys in app state to control when to hide recipe details
- update Korean translations and unit tests to cover the new guidance UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de3ccb97c08328a099233aa6ce5316