### PR TITLE
Remove fallback assumptions from video recipe prompt

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -420,16 +420,11 @@ const App: React.FC = () => {
       return;
     }
 
-    const fallbackSource = targetRecipe.ingredientsNeeded.length
-      ? targetRecipe.ingredientsNeeded
-      : selectedIngredients;
-    const sanitizedFallback = sanitizeIngredients(fallbackSource);
-
     setVideoRecipeAnalysis({ recipeName: targetRecipe.recipeName, videoId: video.id });
     setError(null);
 
     try {
-      const analyzedRecipe = await analyzeVideoRecipe(video, sanitizedFallback);
+      const analyzedRecipe = await analyzeVideoRecipe(video);
       setRecipes(current =>
         current.map(recipe => {
           if (recipe.recipeName !== targetRecipe.recipeName) {

--- a/camera-food-reciepe-main/services/videoRecipeService.ts
+++ b/camera-food-reciepe-main/services/videoRecipeService.ts
@@ -37,7 +37,6 @@ interface YouTubeCaptionsResponse {
 
 const DESCRIPTION_LIMIT = 2000;
 const CAPTION_LIMIT = 6000;
-const FALLBACK_WORD_THRESHOLD = 120;
 
 const sanitizeMultiline = (text: string) =>
   text
@@ -192,10 +191,7 @@ const fetchCaptionText = async (videoId: string) => {
   return '';
 };
 
-export async function analyzeVideoRecipe(
-  video: RecipeVideo,
-  fallbackIngredients: string[]
-): Promise<Recipe> {
+export async function analyzeVideoRecipe(video: RecipeVideo): Promise<Recipe> {
   if (!YOUTUBE_API_KEY) {
     throw new Error('error_youtube_api_key');
   }
@@ -231,17 +227,11 @@ export async function analyzeVideoRecipe(
     }
 
     const contextText = contextSections.join('\n\n').trim();
-    const sanitizedFallback = uniqueSanitizedList(fallbackIngredients);
-
-    const wordCount = contextText ? contextText.split(/\s+/).length : 0;
-    const shouldIncludeFallback = wordCount < FALLBACK_WORD_THRESHOLD && sanitizedFallback.length > 0;
-
     const recipe = await getRecipeFromVideoContext({
       videoId: video.id,
       videoTitle: title,
       channelTitle: metadata.channelTitle ?? video.channelTitle,
       contextText,
-      fallbackIngredients: shouldIncludeFallback ? sanitizedFallback : [],
     });
 
     return {


### PR DESCRIPTION
## Summary
- update the Gemini video recipe prompt so the model only relies on provided video context and marks missing details explicitly
- simplify the video recipe analysis flow to stop gathering fallback ingredient lists and align the request payload with the revised prompt
- adjust the UI call site to match the new service signature

## Testing
- npm run test
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68de4490df508328b15e6122fe78a6fa