### PR TITLE
feat: ensure Gemini preserves video instruction order

### DIFF
--- a/camera-food-reciepe-main/services/__tests__/geminiService.test.ts
+++ b/camera-food-reciepe-main/services/__tests__/geminiService.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { buildVideoRecipePrompt } from '../geminiService';
+
+describe('buildVideoRecipePrompt', () => {
+    it('instructs Gemini to preserve original instruction order without regrouping', () => {
+        const prompt = buildVideoRecipePrompt('Video Title: Example\n\nContext details here');
+
+        expect(prompt).toContain(
+            'Keep the instructions in the exact order they appear in the supplied description or transcript and do not regroup, merge, split, or renumber steps.'
+        );
+    });
+});

--- a/camera-food-reciepe-main/services/geminiService.ts
+++ b/camera-food-reciepe-main/services/geminiService.ts
@@ -131,6 +131,17 @@ export async function getRecipeSuggestions(ingredients: string[]): Promise<Recip
     }
 }
 
+export function buildVideoRecipePrompt(metadataLines: string): string {
+    return `You are a culinary assistant that transforms YouTube cooking video context into structured recipes. Use only the provided context from the video to infer the dish name, a short enticing description, ingredients, and clear numbered instructions (at least four steps). Keep the instructions in the exact order they appear in the supplied description or transcript and do not regroup, merge, split, or renumber steps.
+
+Do not invent or assume details beyond the supplied context. If any field cannot be determined, set recipeName and description to "Not specified in video context" and return an array containing "Not specified in video context" for ingredientsNeeded or instructions when necessary.
+
+Context to analyse:
+${metadataLines}
+
+Return only JSON matching the schema.`;
+}
+
 export async function getRecipeFromVideoContext({
     videoId,
     videoTitle,
@@ -154,14 +165,7 @@ export async function getRecipeFromVideoContext({
         .filter((line): line is string => Boolean(line))
         .join('\n\n');
 
-    const prompt = `You are a culinary assistant that transforms YouTube cooking video context into structured recipes. Use only the provided context from the video to infer the dish name, a short enticing description, ingredients, and clear numbered instructions (at least four steps).
-
-Do not invent or assume details beyond the supplied context. If any field cannot be determined, set recipeName and description to "Not specified in video context" and return an array containing "Not specified in video context" for ingredientsNeeded or instructions when necessary.
-
-Context to analyse:
-${metadataLines}
-
-Return only JSON matching the schema.`;
+    const prompt = buildVideoRecipePrompt(metadataLines);
 
     try {
         const response = await ai.models.generateContent({


### PR DESCRIPTION
## Summary
- update the Gemini video-recipe prompt to explicitly preserve the original instruction order and avoid regrouping
- expose the prompt builder and add a unit test to lock in the new wording

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0bf04eca48328a3aa4a7598ea7951