### PR TITLE
Remove step-by-step instruction UI from recipe modals

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -43,7 +43,6 @@ type VideoGuideState = {
   isOpen: boolean;
   recipe: RecipeRecommendation | null;
   video: RecipeVideo | null;
-  instructions: string[];
   missingIngredients: string[];
   transcriptStatus: TranscriptPromptStatus['status'] | 'idle' | 'loading';
   transcriptMessageKey: string | null;
@@ -189,7 +188,6 @@ const App: React.FC = () => {
     isOpen: false,
     recipe: null,
     video: null,
-    instructions: [],
     missingIngredients: [],
     transcriptStatus: 'idle',
     transcriptMessageKey: null,
@@ -1151,7 +1149,6 @@ const App: React.FC = () => {
       isOpen: true,
       recipe,
       video,
-      instructions: [],
       missingIngredients: recipe.missingIngredients,
       transcriptStatus: 'loading',
       transcriptMessageKey: 'recipeModalVideoTranscriptLoading',
@@ -1225,7 +1222,6 @@ const App: React.FC = () => {
         isOpen: true,
         recipe: enrichedRecipe,
         video,
-        instructions: instructionsToUse.length > 0 ? instructionsToUse : recipe.instructions ?? [],
         missingIngredients: enrichedRecipe.missingIngredients ?? recipe.missingIngredients,
         transcriptStatus: transcript.status,
         transcriptMessageKey: transcript.messageKey,
@@ -1262,7 +1258,6 @@ const App: React.FC = () => {
         isOpen: true,
         recipe,
         video,
-        instructions: [],
         missingIngredients: recipe.missingIngredients,
         transcriptStatus: 'error',
         transcriptMessageKey: 'recipeModalVideoTranscriptError',
@@ -1285,7 +1280,6 @@ const App: React.FC = () => {
       isOpen: false,
       recipe: null,
       video: null,
-      instructions: [],
       missingIngredients: [],
       transcriptStatus: 'idle',
       transcriptMessageKey: null,
@@ -1356,7 +1350,6 @@ const App: React.FC = () => {
         <VideoGuideWindow
           recipe={videoGuideState.recipe}
           video={videoGuideState.video}
-          instructions={videoGuideState.instructions}
           missingIngredients={videoGuideState.missingIngredients}
           transcriptStatus={videoGuideState.transcriptStatus}
           transcriptMessageKey={videoGuideState.transcriptMessageKey}

--- a/camera-food-reciepe-main/components/RecipeExperienceModal.tsx
+++ b/camera-food-reciepe-main/components/RecipeExperienceModal.tsx
@@ -25,7 +25,6 @@ const RecipeExperienceModal: React.FC<RecipeExperienceModalProps> = ({ entry, on
     return fallback;
   }, [entry.ingredients, entry.matchedIngredients, entry.missingIngredients]);
 
-  const instructions = entry.instructions ?? [];
   const videos = entry.videos ?? [];
   const selectedVideoId = entry.selectedVideoId ?? null;
   const selectedVideo = useMemo(
@@ -167,34 +166,6 @@ const RecipeExperienceModal: React.FC<RecipeExperienceModalProps> = ({ entry, on
               </div>
             </section>
           )}
-
-          <section className="space-y-4">
-            <div>
-              <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-widest">
-                {t('experienceModalStepsTitle')}
-              </h3>
-              <p className="text-xs text-gray-500">{t('experienceModalStepsSubtitle')}</p>
-            </div>
-            {instructions.length > 0 ? (
-              <div className="grid gap-3 md:grid-cols-2">
-                {instructions.map((instruction, index) => {
-                  const text = instruction.trim();
-                  return (
-                    <div key={`${entry.id}-step-${index}`} className="rounded-2xl border border-gray-200 bg-white p-4 space-y-2 shadow-sm">
-                      <div className="flex items-center gap-2">
-                        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-orange text-white text-sm font-semibold">
-                          {index + 1}
-                        </span>
-                        <p className="text-sm font-semibold text-gray-800">{text}</p>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <p className="text-sm text-gray-500">{t('experienceModalStepsEmpty')}</p>
-            )}
-          </section>
 
           <section className="space-y-4">
             <div className="space-y-1">

--- a/camera-food-reciepe-main/components/VideoGuideWindow.tsx
+++ b/camera-food-reciepe-main/components/VideoGuideWindow.tsx
@@ -6,7 +6,6 @@ import { useLanguage } from '../context/LanguageContext';
 interface VideoGuideWindowProps {
   recipe: RecipeRecommendation;
   video: RecipeVideo;
-  instructions: string[];
   missingIngredients: string[];
   transcriptStatus: TranscriptPromptStatus['status'] | 'idle' | 'loading';
   transcriptMessageKey: string | null;
@@ -42,7 +41,6 @@ const resolveYoutubeEmbedUrl = (url: string): string | null => {
 const VideoGuideWindow: React.FC<VideoGuideWindowProps> = ({
   recipe,
   video,
-  instructions,
   missingIngredients,
   transcriptStatus,
   transcriptMessageKey,
@@ -54,7 +52,6 @@ const VideoGuideWindow: React.FC<VideoGuideWindowProps> = ({
   const embedUrl = useMemo(() => resolveYoutubeEmbedUrl(video.videoUrl), [video.videoUrl]);
   const transcriptMessage = transcriptMessageKey ? t(transcriptMessageKey as any) : null;
   const ingredientsToShow = missingIngredients.length > 0 ? missingIngredients : recipe.missingIngredients;
-  const isTranscriptWarning = transcriptStatus === 'missing' || transcriptStatus === 'error';
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 py-8">
@@ -131,38 +128,6 @@ const VideoGuideWindow: React.FC<VideoGuideWindowProps> = ({
                   >
                     {transcriptMessage}
                   </p>
-                )}
-                {instructions.length > 0 && (
-                  <div className="space-y-3">
-                    <h3 className="text-sm font-semibold text-gray-800">
-                      {isTranscriptWarning
-                        ? t('recipeModalStepByStepCautionTitle')
-                        : t('recipeModalStepByStepTitle')}
-                    </h3>
-                    {isTranscriptWarning && (
-                      <p className="text-xs text-red-500">
-                        {t('recipeModalStepByStepCautionSubtitle')}
-                      </p>
-                    )}
-                    <div className="space-y-3">
-                      {instructions.map((instruction, index) => (
-                        <div
-                          key={`${video.id}-instruction-${index}`}
-                          className="flex items-start gap-3 rounded-2xl border border-brand-orange/20 bg-white/80 p-4 shadow-sm"
-                        >
-                          <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-orange text-sm font-semibold text-white">
-                            {index + 1}
-                          </span>
-                          <p className="text-sm leading-relaxed text-gray-700">{instruction}</p>
-                        </div>
-                      ))}
-                    </div>
-                    <p className="text-right text-[11px] font-semibold uppercase tracking-wide text-brand-orange/80">
-                      {isTranscriptWarning
-                        ? t('recipeModalStepByStepCautionHint')
-                        : t('recipeModalStepByStepHint')}
-                    </p>
-                  </div>
                 )}
               </div>
 

--- a/camera-food-reciepe-main/components/__tests__/VideoGuideWindow.test.tsx
+++ b/camera-food-reciepe-main/components/__tests__/VideoGuideWindow.test.tsx
@@ -8,8 +8,7 @@ import VideoGuideWindow from '../VideoGuideWindow';
 import { LanguageProvider } from '../../context/LanguageContext';
 import type { RecipeRecommendation, RecipeVideo } from '../../types';
 import {
-  recipeModalStepByStepCautionTitle,
-  recipeModalStepByStepCautionHint,
+  recipeModalVideoTranscriptError,
 } from '../../locales/ko';
 
 const baseRecipe: RecipeRecommendation = {
@@ -39,7 +38,6 @@ describe('VideoGuideWindow', () => {
         <VideoGuideWindow
           recipe={baseRecipe}
           video={baseVideo}
-          instructions={['1. 재료 준비', '2. 조리하기']}
           missingIngredients={[]}
           transcriptStatus="error"
           transcriptMessageKey="recipeModalVideoTranscriptError"
@@ -50,7 +48,6 @@ describe('VideoGuideWindow', () => {
       </LanguageProvider>
     );
 
-    expect(html).toContain(recipeModalStepByStepCautionTitle);
-    expect(html).toContain(recipeModalStepByStepCautionHint);
+    expect(html).toContain(recipeModalVideoTranscriptError);
   });
 });


### PR DESCRIPTION
## Summary
- remove the step-by-step instruction panels from the recipe modal so only video messaging and transcript status remain
- drop the instructions prop and state from the video guide window and strip the instructions section from the recipe experience modal
- refresh the recipe and video guide tests to align with the new messaging-only video guidance flow

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e0c850186083288e1ea4a67ff5dcbc