### PR TITLE
Hide journal copy from recipe modal cards

### DIFF
--- a/camera-food-reciepe-main/components/RecipeModal.tsx
+++ b/camera-food-reciepe-main/components/RecipeModal.tsx
@@ -441,16 +441,9 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                   <article key={index} className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 space-y-6">
                     <div className="space-y-6">
                       <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
-                        <div className="space-y-3 flex-1">
-                          <h3 className="text-xl font-semibold text-gray-800">{recipe.recipeName}</h3>
-                          <p className="text-sm text-gray-600 leading-relaxed">{recipe.description}</p>
-
-                          <div className="mt-2 rounded-2xl border border-brand-blue/15 bg-brand-blue/5 p-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                            <div>
-                              <p className="text-sm font-semibold text-brand-blue">{t('recipeModalJournalTitle')}</p>
-                              <p className="text-xs text-brand-blue/70">{t('recipeModalJournalSubtitle')}</p>
-                            </div>
-                            <div className="flex flex-col items-end gap-2">
+                        <div className="flex-1">
+                          <div className="rounded-2xl border border-brand-blue/15 bg-brand-blue/5 p-4">
+                            <div className="flex flex-col items-start gap-2 md:flex-row md:items-center md:gap-3">
                               <button
                                 type="button"
                                 onClick={() => handleSaveToJournal(recipeForDisplay)}
@@ -462,15 +455,17 @@ const RecipeModal: React.FC<RecipeModalProps> = ({
                               >
                                 {isSaved ? t('recipeModalSaveButtonSaved') : t('recipeModalSaveButton')}
                               </button>
-                              {isJustSaved ? (
-                                <p className={`text-xs ${justSavedState?.isNew ? 'text-emerald-600' : 'text-gray-500'}`}>
-                                  {justSavedState?.isNew
-                                    ? t('recipeModalSaveNewSuccess')
-                                    : t('recipeModalSaveExisting')}
-                                </p>
-                              ) : (
-                                isSaved && <p className="text-xs text-gray-500">{t('recipeModalSaveExisting')}</p>
-                              )}
+                              <div className="min-h-[1.25rem]">
+                                {isJustSaved ? (
+                                  <p className={`text-xs ${justSavedState?.isNew ? 'text-emerald-600' : 'text-gray-500'}`}>
+                                    {justSavedState?.isNew
+                                      ? t('recipeModalSaveNewSuccess')
+                                      : t('recipeModalSaveExisting')}
+                                  </p>
+                                ) : (
+                                  isSaved && <p className="text-xs text-gray-500">{t('recipeModalSaveExisting')}</p>
+                                )}
+                              </div>
                             </div>
                           </div>
                         </div>

--- a/camera-food-reciepe-main/locales/ko.ts
+++ b/camera-food-reciepe-main/locales/ko.ts
@@ -269,8 +269,6 @@ export const journalQuickLogFirst = '오늘 첫 요리 기록';
 export const journalDelete = '기록에서 삭제';
 export const journalLastCooked = '마지막 요리: {{date}}';
 
-export const recipeModalJournalTitle = '이 레시피를 기록장에 저장하기';
-export const recipeModalJournalSubtitle = '다음에 참고할 변형, 양 조절, 만든 횟수를 한곳에 모아두세요.';
 export const recipeModalSaveButton = '기록에 추가';
 export const recipeModalSaveButtonSaved = '이미 저장됨';
 export const recipeModalSaveNewSuccess = '기록장에 추가했어요!';


### PR DESCRIPTION
## Summary
- restructure the recipe modal card header to remove the recipe name/description and journal callout while preserving the save button and status badge layout
- drop the unused Korean journal title/subtitle locale strings now that the copy is no longer rendered

## Testing
- npm test
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e0d47c48f4832883f52940f74f00c7