### PR TITLE
Adjust bottom toolbar safe area spacing

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -1216,7 +1216,7 @@ const App: React.FC = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-[#EBF5FF] via-[#E2F0FF] to-[#7CB7FF]/30 font-sans text-[#1C2B4B]">
       <Header />
-      <main className="container mx-auto max-w-5xl px-4 py-6 md:py-10 pb-36 space-y-8">
+      <main className="container mx-auto max-w-5xl px-4 py-6 md:py-10 pb-[calc(env(safe-area-inset-bottom)+9rem)] space-y-8">
         {videoAvailabilityNotice && (
           <div className="rounded-3xl border border-[#7CB7FF]/30 bg-white/80 px-4 py-3 text-sm text-[#1C2B4B]/80 shadow-sm">
             {videoAvailabilityNotice}

--- a/camera-food-reciepe-main/components/BottomToolbar.tsx
+++ b/camera-food-reciepe-main/components/BottomToolbar.tsx
@@ -23,8 +23,14 @@ const BottomToolbar: React.FC<BottomToolbarProps> = ({ actions }) => {
   };
 
   return (
-    <nav className="fixed inset-x-6 bottom-3 z-40">
-      <div className="rounded-2xl border border-[#7CB7FF]/30 bg-[#E2F0FF]/90 backdrop-blur-xl px-3 py-2 shadow-[0_12px_24px_rgba(124,183,255,0.28)]">
+    <nav
+      className="fixed inset-x-6 bottom-0 z-40"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 0.75rem)' }}
+    >
+      <div
+        className="rounded-2xl border border-[#7CB7FF]/30 bg-[#E2F0FF]/90 backdrop-blur-xl px-3 pt-2 shadow-[0_12px_24px_rgba(124,183,255,0.28)]"
+        style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 0.75rem)' }}
+      >
         <div className="grid gap-2" style={columnStyle}>
           {actions.map(action => (
             <button


### PR DESCRIPTION
## Summary
- add safe-area-aware padding to the bottom toolbar container and panel so it floats above home indicator chrome
- adjust the main layout padding to account for the toolbar height using safe area calculations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0e6f320fc832897dfac2d291a0740