### PR TITLE
Focus nutrition view after scan analysis

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -679,15 +679,16 @@ const App: React.FC = () => {
       setIsMoodboardLoading(true);
       setMoodboardImage(null);
       commitDetectedIngredients(sanitizedDetectedIngredients);
+      applyNutritionFrom(sanitizedDetectedIngredients, {
+        alreadySanitized: true,
+        focusView: true,
+        context: { type: 'scan' },
+      });
       setManualIngredientsInput(sanitizedDetectedIngredients.join('\n'));
       setManualInputError(null);
       setSelectedIngredients([]);
       setRecipes([]);
-      setNutritionSummary(null);
-      setNutritionIngredients([]);
-      setNutritionContext(null);
       setRecipeModalOpen(false);
-      setActiveView('pantry');
 
       try {
         const previewResult = await generateDesignPreview(sanitizedDetectedIngredients);


### PR DESCRIPTION
## Summary
- apply the nutrition summary immediately after committing detected scan ingredients and focus the nutrition panel
- avoid clearing nutrition state during camera scans so the new summary remains visible
- add a scan flow test that mocks photo analysis and asserts the nutrition view is activated with populated data

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0f969071c8328a50b1706303c063a