### PR TITLE
feat: surface nutrition after video selection

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -1176,6 +1176,14 @@ const App: React.FC = () => {
       };
       setVideoRecipe(enrichedRecipe);
       setVideoTranscriptState({ status: transcript.status, messageKey: transcript.messageKey });
+      const appliedIngredients = applyNutritionFrom(enrichedRecipe.ingredientsNeeded, {
+        alreadySanitized: true,
+        focusView: true,
+        context: { type: 'recipe', label: recipe.recipeName },
+      });
+      if (appliedIngredients.length > 0) {
+        setRecipeModalOpen(false);
+      }
       setVideoRecipeSelection(current => {
         if (!current || current.video.id !== video.id) {
           return current;


### PR DESCRIPTION
## Summary
- apply nutrition focus when a recipe video enrichment succeeds and close the modal so the nutrition view is revealed
- add integration coverage that mocks video enrichment and asserts the nutrition panel becomes active after a video selection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0f969aa388328b81921a8a14288d9