### PR TITLE
feat: surface nutrition summary after camera scan

### DIFF
--- a/camera-food-reciepe-main/App.tsx
+++ b/camera-food-reciepe-main/App.tsx
@@ -679,15 +679,16 @@ const App: React.FC = () => {
       setIsMoodboardLoading(true);
       setMoodboardImage(null);
       commitDetectedIngredients(sanitizedDetectedIngredients);
+      applyNutritionFrom(sanitizedDetectedIngredients, {
+        alreadySanitized: true,
+        focusView: true,
+        context: { type: 'scan' },
+      });
       setManualIngredientsInput(sanitizedDetectedIngredients.join('\n'));
       setManualInputError(null);
       setSelectedIngredients([]);
       setRecipes([]);
-      setNutritionSummary(null);
-      setNutritionIngredients([]);
-      setNutritionContext(null);
       setRecipeModalOpen(false);
-      setActiveView('pantry');
 
       try {
         const previewResult = await generateDesignPreview(sanitizedDetectedIngredients);


### PR DESCRIPTION
## Summary
- apply nutrition details immediately after camera scans commit ingredients and switch to the nutrition view
- avoid clearing freshly generated nutrition data on successful scans
- expand tests to cover the scan flow with mocked photo analysis

## Testing
- npm run test
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e0fc5679f08328b61369e65f765dc8